### PR TITLE
feat: convert to node package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 npm-debug.log
+cache/*.json

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This is an AWS IoT Thing simulator for nRF91. This project combines the [device-
 # install deps
 npm ci
 
+# create cache dir (for certs)
+mkdir cache
+
 # compile to js
 npm run build
 
@@ -18,7 +21,7 @@ npm run build
 https://stedolan.github.io/jq/download/
 ```
 
-## Commands
+## Options
 These are the options. Most of them are set with environment variables.
 
 ```
@@ -38,9 +41,13 @@ These are the options. Most of them are set with environment variables.
 
 Use `npx nrfsim --help` to see the most recent list of options.
 
-## Installation
-```
+## Installation (in another repo)
+```bash
+# install package
 npm i -D @nrfcloud/device-simulator-v2
+
+# create directory to cache device certificates
+mkdir cache
 ```
 
 ## Usage
@@ -56,9 +63,15 @@ npx nrfsim -k <api key>
 ### Link device to your account
 This will create a new device and link it to the account associated with the API key.
 ```
-npx nrfsim -k <api key> -l
+npx nrfsim -k <api key> -d <device id (optional)> -l
 ```
 
+### Run GPS sensor
+```
+npx nrfsim -k <api key> -d <device id> -s gps
+```
+
+## Recipes
 ### Connect a device and subscribe to the job updates MQTT topic
 
 1. Log in to [nrfcloud.com](https://nrfcloud.com) and go to the accounts page and grab your API key.

--- a/README.md
+++ b/README.md
@@ -6,20 +6,40 @@
 
 This is an AWS IoT Thing simulator for nRF91. This project combines the [device-simulator](https://github.com/nRFCloud/device-simulator) and [dfu-device-simulator](https://github.com/nRFCloud/dfu-device-simulator) projects. It omits the legacy pairing mechanism and uses the Device API for creating JITP certs and associating a newly provisioned device with your tenant.
 
-### Getting Started
+## Getting Started
 ```sh
 # install deps
-npm i
+npm ci
 
 # compile to js
-npx tsc
+npm run build
 
 # install jq
 https://stedolan.github.io/jq/download/
 ```
 
-### Commands
-See [simulator.ts](src/simulator.ts) for the options. Most of these are set with environment variables.
+## Commands
+These are the options. Most of them are set with environment variables.
+
+```
+  -c, --certs-response <certsResponse>             Response from our device API (default: process.env.CERTS_RESPONSE)
+
+  -e, --endpoint <endpoint>                        AWS IoT MQTT endpoint (default: process.env.MQTT_ENDPOINT)
+
+  -d, --device-id <deviceId>                       ID of the device (default: process.env.DEVICE_ID)
+
+  -a, --app-fw-version <appFwVersion>              Version of the app firmware (default: 1)
+
+  -m, --mqtt-messages-prefix <mqttMessagesPrefix>  The prefix used by tenant for sending and receiving messages
+
+  -s, --services <services>                        Comma-delimited list of services to enable. Any of: [gps,acc,temp,device]
+
+  -h, --help                                       Output usage information
+```
+
+Use `node dist/index.js --help` to see the most recent list of options.
+
+## Usage
 
 ### Connect a device and subscribe to the job updates MQTT topic
 
@@ -45,7 +65,7 @@ export MQTT_ENDPOINT=$(aws iot describe-endpoint --endpoint-type iot:Data-ATS | 
 
 5. Run the simulator, which will just-in-time provision (JITP) the device on nRFCloud and subscribe it to the job updates topic (*NOTE*: JITP can take 20-30 seconds, so be patient...):
 ```sh
-node dist/simulator.js
+node dist/index.js
 ```
 You should see some JSON output, with something like this at the end:
 ```sh
@@ -71,7 +91,7 @@ export MQTT_MESSAGES_PREFIX=$(curl $API_HOST/v1/account -H "Authorization: Beare
 ```
 5. Restart the simulator:
 ```sh
-node dist/simulator.js
+node dist/index.js
 ```
 You should now see an additional line of JSON output indicating that your device has successfully subscribed to the jobs topic for DFU:
 ```sh
@@ -106,7 +126,7 @@ curl -X POST $API_HOST/v1/dfu-jobs -H "Authorization: Bearer $API_KEY" -d '{ "de
 curl $API_HOST/v1/dfu-jobs -H "Authorization: Bearer $API_KEY" | jq
 ```
 
-8. Verify the job succeeded in the other tab where you ran `node dist/simulator.js`. You should see something like:
+8. Verify the job succeeded in the other tab where you ran `node dist/index.js`. You should see something like:
 ```sh
 < $aws/things/nrf-9354733136/jobs/notify-next
 <
@@ -121,11 +141,11 @@ previously created jobs that has a status other than `SUCCEEDED`.
 1. Shut down the script (CMD or CTRL + C).
 2. Restart the simulator with the GPS service enabled:
 ```sh
-node dist/simulator.js -s gps
+node dist/index.js -s gps
 ```
 Or restart the simulator with all the services enabled:
 ```sh
-node dist/simulator.js -s gps,acc,device,temp
+node dist/index.js -s gps,acc,device,temp
 ```
 If you want to use different data simply replace the appropriate file in [./data/sensors](https://github.com/nRFCloud/device-simulator-v2/tree/master/data/sensors) or change tne appropriate file path(s) in [simulator.ts](src/simulator.ts). (There is some additional GPS data in this repo for routes around Portland, Oregon.)
 

--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ https://stedolan.github.io/jq/download/
 These are the options. Most of them are set with environment variables.
 
 ```
-  -c, --certs-response <certsResponse>               JSON returned by call to the Device API: POST /devices/{deviceid}/certificates (default: "")
+  -c, --certs-response <certsResponse>               JSON returned by call POST /devices/{deviceid}/certificates (default: "")
   -e, --endpoint <endpoint>                          AWS IoT MQTT endpoint (default: "")
   -d, --device-id <deviceId>                         ID of the device (default: "rand")
   -o, --device-ownership-code <deviceOwnershipCode>  PIN/ownership code of the device (default: "123456")
   -m, --mqtt-messages-prefix <mqttMessagesPrefix>    The prefix for the MQTT for this tenant for sending and receiving device messages (default: "")
   -s, --services <services>                          Comma-delimited list of services to enable. Any of: [gps,acc,temp,device]
-  -a, --app-fw-version <appFwVersion>                Version of the app firmware (default: 1)
+  -f, --app-fw-version <appFwVersion>                Version of the app firmware (default: 1)
   -k, --api-key <apiKey>                             API key for nRF Cloud (default: "")
   -h, --api-host <apiHost>                           API host for nRF Cloud (default: "https://api.dev.nrfcloud.com")
-  -l, --link                                         Whether or not to automatically link device to account (default: false)
-  -v, --verbose                                      Verbose
+  -a, --associate                                    Automatically associate device to your account (default: false)
+  -v, --verbose                                      Output debug information
   -h, --help                                         Output usage information
 ```
 
-Use `npx nrfsim --help` to see the most recent list of options.
+Use `npx device-simulator-v2 --help` to see the most recent list of options.
 
 ## Installation (in another repo)
 ```bash
@@ -53,22 +53,22 @@ mkdir cache
 ## Usage
 
 ### Most basic usage
-The most basic usage is just sending in the API key. The device ID will be randomly generated and the rest of the necessary information (mqtt endpoint, cert, and mqtt prefix) will be pulled from the device API. 
+The most basic usage is just creating a device. For that you just need an API key. The device ID will be randomly generated and the rest of the necessary information (mqtt endpoint, cert, and mqtt prefix) will be pulled from the device API. 
 
-This will create a new device with AWS IoT, it will not connect it to your account (use the `-l` flag) for that.
+This will create a new device with AWS IoT, it will not associate it to your account (use the `-a` flag) for that.
 ```
-npx nrfsim -k <api key>
+npx device-simulator-v2 -k <api key>
 ```
 
-### Link device to your account
-This will create a new device and link it to the account associated with the API key.
+### Associate device to your account
+This will create a new device and associate it to the account for the API key.
 ```
-npx nrfsim -k <api key> -d <device id (optional)> -l
+npx device-simulator-v2 -k <api key> -d <device id (optional)> -a
 ```
 
 ### Run GPS sensor
 ```
-npx nrfsim -k <api key> -d <device id> -s gps
+npx device-simulator-v2 -k <api key> -d <device id (optional)> -s gps
 ```
 
 ## Recipes
@@ -96,7 +96,7 @@ export MQTT_ENDPOINT=$(aws iot describe-endpoint --endpoint-type iot:Data-ATS | 
 
 5. Run the simulator, which will just-in-time provision (JITP) the device on nRFCloud and subscribe it to the job updates topic (*NOTE*: JITP can take 20-30 seconds, so be patient...):
 ```sh
-npx nrfsim
+npx device-simulator-v2
 ```
 You should see some JSON output, with something like this at the end:
 ```sh
@@ -122,7 +122,7 @@ export MQTT_MESSAGES_PREFIX=$(curl $API_HOST/v1/account -H "Authorization: Beare
 ```
 5. Restart the simulator:
 ```sh
-npx nrfsim
+npx device-simulator-v2
 ```
 You should now see an additional line of JSON output indicating that your device has successfully subscribed to the jobs topic for DFU:
 ```sh
@@ -157,7 +157,7 @@ curl -X POST $API_HOST/v1/dfu-jobs -H "Authorization: Bearer $API_KEY" -d '{ "de
 curl $API_HOST/v1/dfu-jobs -H "Authorization: Bearer $API_KEY" | jq
 ```
 
-8. Verify the job succeeded in the other tab where you ran `npx nrfsim`. You should see something like:
+8. Verify the job succeeded in the other tab where you ran `npx device-simulator-v2`. You should see something like:
 ```sh
 < $aws/things/nrf-9354733136/jobs/notify-next
 <
@@ -172,11 +172,11 @@ previously created jobs that has a status other than `SUCCEEDED`.
 1. Shut down the script (CMD or CTRL + C).
 2. Restart the simulator with the GPS service enabled:
 ```sh
-npx nrfsim -s gps
+npx device-simulator-v2 -s gps
 ```
 Or restart the simulator with all the services enabled:
 ```sh
-npx nrfsim -s gps,acc,device,temp
+npx device-simulator-v2 -s gps,acc,device,temp
 ```
 If you want to use different data simply replace the appropriate file in [./data/sensors](https://github.com/nRFCloud/device-simulator-v2/tree/master/data/sensors) or change tne appropriate file path(s) in [simulator.ts](src/simulator.ts). (There is some additional GPS data in this repo for routes around Portland, Oregon.)
 

--- a/README.md
+++ b/README.md
@@ -22,30 +22,42 @@ https://stedolan.github.io/jq/download/
 These are the options. Most of them are set with environment variables.
 
 ```
-  -c, --certs-response <certsResponse>               Response from our device API (default: process.env.CERTS_RESPONSE)
-
-  -e, --endpoint <endpoint>                          AWS IoT MQTT endpoint (default: process.env.MQTT_ENDPOINT)
-
-  -d, --device-id <deviceId>                         ID of the device (default: process.env.DEVICE_ID)
-
-  -o, --device-ownership-code <deviceOwnershipCode>  PIN/ownership code of the device (default: process.env.DEVICE_OWNERSHIP_CODE)
-
-  -k, --api-key <apiKey>                             API key for nRF Cloud (default: process.env.API_KEY)
-
-  -h, --api-host <apiHost>                           API host for nRF Cloud (default: process.env.API_HOST || "https://api.dev.nrfcloud.com")
-
-  -a, --app-fw-version <appFwVersion>                Version of the app firmware (default: 1)
-
-  -m, --mqtt-messages-prefix <mqttMessagesPrefix>    The prefix used by tenant for sending and receiving messages
-
+  -c, --certs-response <certsResponse>               JSON returned by call to the Device API: POST /devices/{deviceid}/certificates (default: "")
+  -e, --endpoint <endpoint>                          AWS IoT MQTT endpoint (default: "")
+  -d, --device-id <deviceId>                         ID of the device (default: "rand")
+  -o, --device-ownership-code <deviceOwnershipCode>  PIN/ownership code of the device (default: "123456")
+  -m, --mqtt-messages-prefix <mqttMessagesPrefix>    The prefix for the MQTT for this tenant for sending and receiving device messages (default: "")
   -s, --services <services>                          Comma-delimited list of services to enable. Any of: [gps,acc,temp,device]
-
+  -a, --app-fw-version <appFwVersion>                Version of the app firmware (default: 1)
+  -k, --api-key <apiKey>                             API key for nRF Cloud (default: "")
+  -h, --api-host <apiHost>                           API host for nRF Cloud (default: "https://api.dev.nrfcloud.com")
+  -l, --link                                         Whether or not to automatically link device to account (default: false)
+  -v, --verbose                                      Verbose
   -h, --help                                         Output usage information
 ```
 
-Use `node dist/index.js --help` to see the most recent list of options.
+Use `npx nrfsim --help` to see the most recent list of options.
+
+## Installation
+```
+npm i -D @nrfcloud/device-simulator-v2
+```
 
 ## Usage
+
+### Most basic usage
+The most basic usage is just sending in the API key. The device ID will be randomly generated and the rest of the necessary information (mqtt endpoint, cert, and mqtt prefix) will be pulled from the device API. 
+
+This will create a new device with AWS IoT, it will not connect it to your account (use the `-l` flag) for that.
+```
+npx nrfsim -k <api key>
+```
+
+### Link device to your account
+This will create a new device and link it to the account associated with the API key.
+```
+npx nrfsim -k <api key> -l
+```
 
 ### Connect a device and subscribe to the job updates MQTT topic
 
@@ -71,7 +83,7 @@ export MQTT_ENDPOINT=$(aws iot describe-endpoint --endpoint-type iot:Data-ATS | 
 
 5. Run the simulator, which will just-in-time provision (JITP) the device on nRFCloud and subscribe it to the job updates topic (*NOTE*: JITP can take 20-30 seconds, so be patient...):
 ```sh
-node dist/index.js
+npx nrfsim
 ```
 You should see some JSON output, with something like this at the end:
 ```sh
@@ -97,7 +109,7 @@ export MQTT_MESSAGES_PREFIX=$(curl $API_HOST/v1/account -H "Authorization: Beare
 ```
 5. Restart the simulator:
 ```sh
-node dist/index.js
+npx nrfsim
 ```
 You should now see an additional line of JSON output indicating that your device has successfully subscribed to the jobs topic for DFU:
 ```sh
@@ -132,7 +144,7 @@ curl -X POST $API_HOST/v1/dfu-jobs -H "Authorization: Bearer $API_KEY" -d '{ "de
 curl $API_HOST/v1/dfu-jobs -H "Authorization: Bearer $API_KEY" | jq
 ```
 
-8. Verify the job succeeded in the other tab where you ran `node dist/index.js`. You should see something like:
+8. Verify the job succeeded in the other tab where you ran `npx nrfsim`. You should see something like:
 ```sh
 < $aws/things/nrf-9354733136/jobs/notify-next
 <
@@ -147,11 +159,11 @@ previously created jobs that has a status other than `SUCCEEDED`.
 1. Shut down the script (CMD or CTRL + C).
 2. Restart the simulator with the GPS service enabled:
 ```sh
-node dist/index.js -s gps
+npx nrfsim -s gps
 ```
 Or restart the simulator with all the services enabled:
 ```sh
-node dist/index.js -s gps,acc,device,temp
+npx nrfsim -s gps,acc,device,temp
 ```
 If you want to use different data simply replace the appropriate file in [./data/sensors](https://github.com/nRFCloud/device-simulator-v2/tree/master/data/sensors) or change tne appropriate file path(s) in [simulator.ts](src/simulator.ts). (There is some additional GPS data in this repo for routes around Portland, Oregon.)
 

--- a/README.md
+++ b/README.md
@@ -22,19 +22,25 @@ https://stedolan.github.io/jq/download/
 These are the options. Most of them are set with environment variables.
 
 ```
-  -c, --certs-response <certsResponse>             Response from our device API (default: process.env.CERTS_RESPONSE)
+  -c, --certs-response <certsResponse>               Response from our device API (default: process.env.CERTS_RESPONSE)
 
-  -e, --endpoint <endpoint>                        AWS IoT MQTT endpoint (default: process.env.MQTT_ENDPOINT)
+  -e, --endpoint <endpoint>                          AWS IoT MQTT endpoint (default: process.env.MQTT_ENDPOINT)
 
-  -d, --device-id <deviceId>                       ID of the device (default: process.env.DEVICE_ID)
+  -d, --device-id <deviceId>                         ID of the device (default: process.env.DEVICE_ID)
 
-  -a, --app-fw-version <appFwVersion>              Version of the app firmware (default: 1)
+  -o, --device-ownership-code <deviceOwnershipCode>  PIN/ownership code of the device (default: process.env.DEVICE_OWNERSHIP_CODE)
 
-  -m, --mqtt-messages-prefix <mqttMessagesPrefix>  The prefix used by tenant for sending and receiving messages
+  -k, --api-key <apiKey>                             API key for nRF Cloud (default: process.env.API_KEY)
 
-  -s, --services <services>                        Comma-delimited list of services to enable. Any of: [gps,acc,temp,device]
+  -h, --api-host <apiHost>                           API host for nRF Cloud (default: process.env.API_HOST || "https://api.dev.nrfcloud.com")
 
-  -h, --help                                       Output usage information
+  -a, --app-fw-version <appFwVersion>                Version of the app firmware (default: 1)
+
+  -m, --mqtt-messages-prefix <mqttMessagesPrefix>    The prefix used by tenant for sending and receiving messages
+
+  -s, --services <services>                          Comma-delimited list of services to enable. Any of: [gps,acc,temp,device]
+
+  -h, --help                                         Output usage information
 ```
 
 Use `node dist/index.js --help` to see the most recent list of options.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1438,6 +1438,12 @@
         }
       }
     },
+    "ez-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ez-cache/-/ez-cache-1.0.1.tgz",
+      "integrity": "sha1-KFASWlSBm8yOaJNEMVNQ227ESGE=",
+      "dev": true
+    },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1152,11 +1152,6 @@
         "is-obj": "^1.0.0"
       }
     },
-    "dotenv": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
-      "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
-    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -470,6 +470,24 @@
         "xml2js": "0.4.19"
       }
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
+      }
+    },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
@@ -1472,6 +1490,32 @@
       "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
       "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "aws-sdk": "^2.470.0",
     "colors": "^1.3.2",
     "commander": "^2.19.0",
-    "dotenv": "^8.0.0",
     "event-stream": "^4.0.1",
     "tcomb": "^3.2.28",
     "uuid": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "description": "AWS IoT Thing simulator for nRF91",
   "scripts": {
+    "build": "npx tsc",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "npm run tslint && npm run prettier:lint",
     "tslint": "tslint --project ./tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/jest": "^24.0.11",
     "@types/node": "^12.0.7",
     "@types/uuid": "^3.4.4",
+    "axios": "^0.19.0",
     "husky": "^2.4.0",
     "json-schema-to-typescript": "^7.1.0",
     "lint-staged": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "@nrfcloud/device-simulator-v2",
   "version": "0.0.0-development",
   "description": "AWS IoT Thing simulator for nRF91",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "nrfdevice": "./dist/index.js"
+  },
   "scripts": {
     "build": "npx tsc",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "nrfdevice": "./dist/index.js"
+    "nrfsim": "./dist/index.js"
   },
   "scripts": {
     "build": "npx tsc",
@@ -36,6 +36,7 @@
     "@types/node": "^12.0.7",
     "@types/uuid": "^3.4.4",
     "axios": "^0.19.0",
+    "ez-cache": "^1.0.1",
     "husky": "^2.4.0",
     "json-schema-to-typescript": "^7.1.0",
     "lint-staged": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "nrfsim": "./dist/index.js"
+    "device-simulator-v2": "./dist/index.js"
   },
   "scripts": {
     "build": "npx tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,11 @@ program
     process.env.MQTT_ENDPOINT,
   )
   .option(
+    '-d, --device-id <deviceId>',
+    'ID of the device',
+    process.env.DEVICE_ID,
+  )
+  .option(
     '-a, --app-fw-version <appFwVersion>',
     'Version of the app firmware',
     1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ dotenv.config();
 
 program
   .option(
-    '-cr, --certs-response <certsResponse>',
+    '-c, --certs-response <certsResponse>',
     'JSON returned by call to the Device API endpoint: POST /devices/{deviceid}/certificates',
     process.env.CERTS_RESPONSE,
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,47 +7,32 @@ import { simulator, SimulatorConfig } from './simulator';
 dotenv.config();
 
 program
-    .option(
-        '-cr, --certs-response <certsResponse>',
-        'JSON returned by call to the Device API endpoint: POST /devices/{deviceid}/certificates',
-        process.env.CERTS_RESPONSE,
-    )
-    .option(
-        '-d, --deviceId <deviceId>',
-        'id of the device',
-        process.env.DEVICE_ID,
-    )
-    .option(
-        '-c, --certificate <certificate>',
-        'location of the device certificate',
-        process.env.DEVICE_CERTIFICATE,
-    )
-    .option(
-        '-k, --key <key>',
-        'location of the device private key',
-        process.env.DEVICE_KEY,
-    )
-    .option(
-        '-e, --endpoint <endpoint>',
-        'AWS IoT MQTT endpoint',
-        process.env.MQTT_ENDPOINT,
-    )
-    .option(
-        '-a, --app-fw-version <appFwVersion>',
-        'Version of the app firmware',
-        1,
-    )
-    .option(
-        '-m, --mqtt-messages-prefix <mqttMessagesPrefix>',
-        'The prefix for the MQTT unique to this tenant for sending and receiving device messages',
-        process.env.MQTT_MESSAGES_PREFIX,
-    )
-    .option(
-        '-s, --services <services>',
-        'Comma-delimited list of services to enable. Any of: [gps,acc,temp,device]',
-    )
-    .parse(process.argv);
+  .option(
+    '-cr, --certs-response <certsResponse>',
+    'JSON returned by call to the Device API endpoint: POST /devices/{deviceid}/certificates',
+    process.env.CERTS_RESPONSE,
+  )
+  .option(
+    '-e, --endpoint <endpoint>',
+    'AWS IoT MQTT endpoint',
+    process.env.MQTT_ENDPOINT,
+  )
+  .option(
+    '-a, --app-fw-version <appFwVersion>',
+    'Version of the app firmware',
+    1,
+  )
+  .option(
+    '-m, --mqtt-messages-prefix <mqttMessagesPrefix>',
+    'The prefix for the MQTT unique to this tenant for sending and receiving device messages',
+    process.env.MQTT_MESSAGES_PREFIX,
+  )
+  .option(
+    '-s, --services <services>',
+    'Comma-delimited list of services to enable. Any of: [gps,acc,temp,device]',
+  )
+  .parse(process.argv);
 
-simulator(program.opts() as SimulatorConfig).catch(error => {
-    process.stderr.write(`${red(error)}\n`);
+simulator((program as unknown) as SimulatorConfig).catch(error => {
+  process.stderr.write(`${red(error)}\n`);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,41 +3,128 @@ import * as program from 'commander';
 import { red } from 'colors';
 import * as dotenv from 'dotenv';
 import { simulator, SimulatorConfig } from './simulator';
+const axios = require('axios');
 
 dotenv.config();
 
-program
-  .option(
-    '-c, --certs-response <certsResponse>',
-    'JSON returned by call to the Device API endpoint: POST /devices/{deviceid}/certificates',
-    process.env.CERTS_RESPONSE,
-  )
-  .option(
-    '-e, --endpoint <endpoint>',
-    'AWS IoT MQTT endpoint',
-    process.env.MQTT_ENDPOINT,
-  )
-  .option(
-    '-d, --device-id <deviceId>',
-    'ID of the device',
-    process.env.DEVICE_ID,
-  )
-  .option(
-    '-a, --app-fw-version <appFwVersion>',
-    'Version of the app firmware',
-    1,
-  )
-  .option(
-    '-m, --mqtt-messages-prefix <mqttMessagesPrefix>',
-    'The prefix for the MQTT unique to this tenant for sending and receiving device messages',
-    process.env.MQTT_MESSAGES_PREFIX,
-  )
-  .option(
-    '-s, --services <services>',
-    'Comma-delimited list of services to enable. Any of: [gps,acc,temp,device]',
-  )
-  .parse(process.argv);
+const getConfig = (env: any): SimulatorConfig =>
+  program
+    .option(
+      '-c, --certs-response <certsResponse>',
+      'JSON returned by call to the Device API endpoint: POST /devices/{deviceid}/certificates',
+      env.CERTS_RESPONSE,
+    )
+    .option(
+      '-e, --endpoint <endpoint>',
+      'AWS IoT MQTT endpoint',
+      env.MQTT_ENDPOINT,
+    )
+    .option(
+      '-d, --device-id <deviceId>',
+      'ID of the device',
+      env.DEVICE_ID,
+    )
+    .option(
+      '-o, --device-ownership-code <deviceOwnershipCode>',
+      'PIN/ownership code of the device',
+      env.DEVICE_OWNERSHIP_CODE,
+    )
+    .option(
+      '-k, --api-key <apiKey>',
+      'API key for nRF Cloud',
+      process.env.API_KEY,
+    )
+    .option(
+      '-k, --api-host <apiHost>',
+      'API host for nRF Cloud',
+      process.env.API_HOST || 'https://api.dev.nrfcloud.com',
+    )
+    .option(
+      '-s, --services <services>',
+      'Comma-delimited list of services to enable. Any of: [gps,acc,temp,device]',
+    )
+    .option(
+      '-a, --app-fw-version <appFwVersion>',
+      'Version of the app firmware',
+      1,
+    )
+    .option(
+      '-m, --mqtt-messages-prefix <mqttMessagesPrefix>',
+      'The prefix for the MQTT unique to this tenant for sending and receiving device messages',
+      env.MQTT_MESSAGES_PREFIX,
+    )
+    .option(
+      '-s, --services <services>',
+      'Comma-delimited list of services to enable. Any of: [gps,acc,temp,device]',
+    )
+    .parse(process.argv) as unknown as SimulatorConfig;
 
-simulator((program as unknown) as SimulatorConfig).catch(error => {
-  process.stderr.write(`${red(error)}\n`);
-});
+
+(async (): Promise<void> => {
+  const config: SimulatorConfig = getConfig(process.env);
+  const { 
+    deviceId, 
+    apiKey, 
+    apiHost, 
+    certsResponse, 
+    endpoint, 
+    mqttMessagesPrefix,
+    deviceOwnershipCode,
+  } = config;
+
+  if (!deviceId) {
+    console.error(red('A device id is required!'));
+    return;
+  }
+
+  if (!(
+    certsResponse &&
+    endpoint &&
+    mqttMessagesPrefix
+  )) {
+    if (!(apiKey && apiHost && deviceOwnershipCode)) {
+      console.error('apiKey, apiHost, and deviceOwnershipCode are required to set sensible defaults');
+      return;
+    }
+
+    const conn = axios.create({
+      baseURL: apiHost,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      }
+    });
+
+    // const interceptor = conn.interceptors.request.use(config => {
+    // 	console.log(config)
+    // 	return config;
+    // });
+
+    if (!endpoint || !mqttMessagesPrefix) {
+      const {
+        data: { 
+          mqttEndpoint, 
+          topics: { messagesPrefix}
+        }
+      } = await conn.get(`/v1/account`);
+
+      if (!endpoint) {
+        config.endpoint = mqttEndpoint;
+      }
+
+      if (!mqttMessagesPrefix) {
+        config.mqttMessagesPrefix = messagesPrefix;
+      }
+    }
+
+    if (!certsResponse) {
+      const {data} = await conn.post(`/v1/devices/${deviceId}/certificates`, deviceOwnershipCode);
+      config.certsResponse = JSON.stringify(data);
+    }
+  }
+
+  simulator(config).catch(error => {
+    process.stderr.write(`${red(error)}\n`);
+  });
+})()
+
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,12 +62,12 @@ const getConfig = (env: any): SimulatorConfig =>
 
 (async (): Promise<void> => {
   const config: SimulatorConfig = getConfig(process.env);
-  const { 
-    deviceId, 
-    apiKey, 
-    apiHost, 
-    certsResponse, 
-    endpoint, 
+  const {
+    deviceId,
+    apiKey,
+    apiHost,
+    certsResponse,
+    endpoint,
     mqttMessagesPrefix,
     deviceOwnershipCode,
   } = config;
@@ -91,7 +91,7 @@ const getConfig = (env: any): SimulatorConfig =>
       baseURL: apiHost,
       headers: {
         Authorization: `Bearer ${apiKey}`,
-      }
+      },
     });
 
     // const interceptor = conn.interceptors.request.use(config => {
@@ -101,10 +101,10 @@ const getConfig = (env: any): SimulatorConfig =>
 
     if (!endpoint || !mqttMessagesPrefix) {
       const {
-        data: { 
-          mqttEndpoint, 
-          topics: { messagesPrefix}
-        }
+        data: {
+          mqttEndpoint,
+          topics: { messagesPrefix},
+        },
       } = await conn.get(`/v1/account`);
 
       if (!endpoint) {
@@ -125,6 +125,6 @@ const getConfig = (env: any): SimulatorConfig =>
   simulator(config).catch(error => {
     process.stderr.write(`${red(error)}\n`);
   });
-})()
+})();
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,6 @@ const getConfig = (args: any, env: any): SimulatorConfig =>
     .parse(args)
     .opts() as SimulatorConfig;
 
-// i don't understand this 'no-floating-promises' rule.
 // so I'm using the javascript 'void' operator:  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void
 // ¯\_(ツ)_/¯
 (async (): Promise<void> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import * as program from 'commander';
+import { red } from 'colors';
+import * as dotenv from 'dotenv';
+import { simulator, SimulatorConfig } from './simulator';
+
+dotenv.config();
+
+program
+    .option(
+        '-cr, --certs-response <certsResponse>',
+        'JSON returned by call to the Device API endpoint: POST /devices/{deviceid}/certificates',
+        process.env.CERTS_RESPONSE,
+    )
+    .option(
+        '-d, --deviceId <deviceId>',
+        'id of the device',
+        process.env.DEVICE_ID,
+    )
+    .option(
+        '-c, --certificate <certificate>',
+        'location of the device certificate',
+        process.env.DEVICE_CERTIFICATE,
+    )
+    .option(
+        '-k, --key <key>',
+        'location of the device private key',
+        process.env.DEVICE_KEY,
+    )
+    .option(
+        '-e, --endpoint <endpoint>',
+        'AWS IoT MQTT endpoint',
+        process.env.MQTT_ENDPOINT,
+    )
+    .option(
+        '-a, --app-fw-version <appFwVersion>',
+        'Version of the app firmware',
+        1,
+    )
+    .option(
+        '-m, --mqtt-messages-prefix <mqttMessagesPrefix>',
+        'The prefix for the MQTT unique to this tenant for sending and receiving device messages',
+        process.env.MQTT_MESSAGES_PREFIX,
+    )
+    .option(
+        '-s, --services <services>',
+        'Comma-delimited list of services to enable. Any of: [gps,acc,temp,device]',
+    )
+    .parse(process.argv);
+
+simulator(program.opts() as SimulatorConfig).catch(error => {
+    process.stderr.write(`${red(error)}\n`);
+});

--- a/src/mqttClient.ts
+++ b/src/mqttClient.ts
@@ -1,11 +1,11 @@
 import { device } from 'aws-iot-device-sdk';
 
 export const mqttClient = ({
+  caCert,
+  clientCert,
+  privateKey,
   id,
   endpoint,
-  caCert,
-  privateKey,
-  clientCert,
 }: {
   caCert: Buffer | string;
   clientCert: Buffer | string;

--- a/src/nrfDevice.ts
+++ b/src/nrfDevice.ts
@@ -64,7 +64,7 @@ export type DeviceConfig = {
 export const nrfdevice = (
   config: DeviceConfig,
   sensors: Map<string, ISensor>,
-  onConnect?: (deviceId: string, device: device) => void,
+  onConnect?: (deviceId: string, client: device) => void,
 ) => {
   const {
     deviceId,

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -1,4 +1,4 @@
-import { cyan, red, yellow } from 'colors';
+import { cyan, yellow } from 'colors';
 import * as path from 'path';
 import { nrfdevice, DeviceConfig } from './nrfDevice';
 import { ISensor } from './sensors/Sensor';
@@ -15,6 +15,9 @@ export type SimulatorConfig = {
   deviceId: string;
   mqttMessagesPrefix: string;
   services?: string;
+  apiKey?: string,
+  apiHost?: string,
+  deviceOwnershipCode?: string,
   onConnect?: (deviceId: string, device: device) => void;
 };
 
@@ -22,16 +25,10 @@ export const simulator = async ({
   certsResponse,
   endpoint,
   appFwVersion,
-  deviceId,
   mqttMessagesPrefix,
   services = '',
   onConnect,
 }: SimulatorConfig): Promise<void> => {
-  if (!deviceId) {
-    console.error(red('A device id is required!'));
-    return;
-  }
-
   let certs;
 
   try {

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -19,7 +19,7 @@ export type SimulatorConfig = {
   apiHost?: string;
   deviceOwnershipCode?: string;
   verbose?: boolean;
-  link?: boolean;
+  associate?: boolean;
   onConnect?: (deviceId: string, client: device) => void;
 };
 

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -15,9 +15,10 @@ export type SimulatorConfig = {
   deviceId: string;
   mqttMessagesPrefix: string;
   services?: string;
-  apiKey?: string,
-  apiHost?: string,
-  deviceOwnershipCode?: string,
+  apiKey?: string;
+  apiHost?: string;
+  deviceOwnershipCode?: string;
+  verbose?: boolean;
   onConnect?: (deviceId: string, device: device) => void;
 };
 

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -19,7 +19,8 @@ export type SimulatorConfig = {
   apiHost?: string;
   deviceOwnershipCode?: string;
   verbose?: boolean;
-  onConnect?: (deviceId: string, device: device) => void;
+  link?: boolean;
+  onConnect?: (deviceId: string, client: device) => void;
 };
 
 export const simulator = async ({

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -1,6 +1,4 @@
-import * as program from 'commander';
 import { cyan, red, yellow } from 'colors';
-import * as dotenv from 'dotenv';
 import * as path from 'path';
 import { nrfdevice, DeviceConfig } from './nrfDevice';
 import { ISensor } from './sensors/Sensor';
@@ -9,15 +7,30 @@ import { FakeAccelerometer } from './sensors/FakeAccelerometer';
 import { FakeThermometer } from './sensors/FakeThermometer';
 import { FakeDevice } from './sensors/FakeDevice';
 
-dotenv.config();
+export type SimulatorConfig = {
+  deviceId: string,
+  endpoint: string,
+  mqttMessagesPrefix: string
+  certsResponse: string,
+  certificate?: any,
+  key?: any,
+  appFwVersion?: string,
+  services?: string,
+};
 
-const simulator = async ({
+export const simulator = async ({
   certsResponse,
   endpoint,
   appFwVersion,
   mqttMessagesPrefix,
   services,
 }: program.Command) => {
+
+  if (!deviceId) {
+    console.error(red('A device id is required!'));
+    return;
+  }
+
   const certs = JSON.parse(certsResponse);
   const caCert = Buffer.from(certs.caCert, 'utf-8');
   const clientCert = Buffer.from(certs.clientCert, 'utf-8');
@@ -36,6 +49,7 @@ const simulator = async ({
   console.log(cyan(`connecting to ${yellow(endpoint)}...`));
 
   const sensors = new Map<string, ISensor>();
+
   if (services) {
     services.split(',').map((service: string) => {
       const sensorDataFilePath = (filename: string) =>
@@ -81,33 +95,3 @@ const simulator = async ({
   nrfdevice(config, sensors);
 };
 
-program
-  .option(
-    '-cr, --certs-response <certsResponse>',
-    'JSON returned by call to the Device API endpoint: POST /devices/{deviceid}/certificates',
-    process.env.CERTS_RESPONSE,
-  )
-  .option(
-    '-e, --endpoint <endpoint>',
-    'AWS IoT MQTT endpoint',
-    process.env.MQTT_ENDPOINT,
-  )
-  .option(
-    '-a, --app-fw-version <appFwVersion>',
-    'Version of the app firmware',
-    1,
-  )
-  .option(
-    '-m, --mqtt-messages-prefix <mqttMessagesPrefix>',
-    'The prefix for the MQTT unique to this tenant for sending and receiving device messages',
-    process.env.MQTT_MESSAGES_PREFIX,
-  )
-  .option(
-    '-s, --services <services>',
-    'Comma-delimited list of services to enable. Any of: [gps,acc,temp,device]',
-  )
-  .parse(process.argv);
-
-simulator(program).catch(error => {
-  process.stderr.write(`${red(error)}\n`);
-});

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -8,24 +8,22 @@ import { FakeThermometer } from './sensors/FakeThermometer';
 import { FakeDevice } from './sensors/FakeDevice';
 
 export type SimulatorConfig = {
-  deviceId: string,
-  endpoint: string,
-  mqttMessagesPrefix: string
-  certsResponse: string,
-  certificate?: any,
-  key?: any,
-  appFwVersion?: string,
-  services?: string,
+  certsResponse: string;
+  endpoint: string;
+  appFwVersion: string;
+  deviceId: string;
+  mqttMessagesPrefix: string;
+  services?: string;
 };
 
 export const simulator = async ({
   certsResponse,
   endpoint,
   appFwVersion,
+  deviceId,
   mqttMessagesPrefix,
-  services,
-}: program.Command) => {
-
+  services = '',
+}: SimulatorConfig): Promise<void> => {
   if (!deviceId) {
     console.error(red('A device id is required!'));
     return;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es2017",
+        "target": "es5",
         "strict": true,
         "outDir": "dist/",
         "declaration": true,


### PR DESCRIPTION
**Summary**
- Updated TS config to allow the repo to be installed as a node package in other repos.
- Index file now sets sane defaults for cert/prefix/mqtt endpoint from device API automatically
- Device ID is now automatically generated if not provided
- Certs are cached on the filesystem, so they don't need to be fetched from API every time
- Added option to link device to account automatically
- Updated `simulator.ts` file to be used in FE e2e tests

**Testing**
- `npm link` in project directory
- `npm link @nrfcloud/device-simulator-v2` in another npm initialized directory
- `npx device-simulator-v2 -k <api key> -l`
- Check your (dev) account for the device you just added

**TODO**
- [ ] `npm publish` after PR is approved