### PR TITLE
fix: match changes for iris-3244 FetchAccountInfo device API changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ export const getDefaults = async ({
     if (!(defaultEndpoint && defaultMqttMessagesPrefix)) {
       log.debug('Fetching endpoints from device API.\n');
       const { data } = await conn.get(`/v1/account`);
-      defaultMqttMessagesPrefix = data.topics.messagesPrefix;
+      defaultMqttMessagesPrefix = data.mqttTopicPrefix + '/m';
       defaultEndpoint = data.mqttEndpoint;
     }
 
@@ -139,7 +139,7 @@ export const getDefaults = async ({
 
   if (!tenantId) {
     const { data } = await conn.get(`/v1/account`);
-    tenantId = data.mqttTopicPrefix.split('/')[1];
+    tenantId = data.team.tenantId;
   }
 
   if (!tenantId) {


### PR DESCRIPTION
See BE PR #231. @savvyintegrations defined a change to the list of fields in the response to our Device API's FetchAccountInfo (/account) request, see IRIS-3244 for details.

The device simulator would no longer be able to create a simulated device because it was using `topics.messagesPrefix`, which was removed in the API change. Also, rather than parsing out the tenant from the mqtt topic prefix, it's now part of the API, so use it.

Testing: Nothing should regress.