### PR TITLE
feat: Add device onboarding type 'preconnect' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ This is an AWS IoT Thing simulator for nRF91. It shows how to use the Device API
 ### Most basic usage
 The most basic usage is just creating a device. For that you just need an API key. The device ID will be randomly generated and the rest of the necessary information (mqtt endpoint, cert, and mqtt prefix) will be pulled from the device API. 
 
-The host defaults to the production environment (https://api.nrfcloud.com). **Nordic Semiconductor personnel**: if you want to use the simulator on our `dev`, `feature`, or `beta` environments, set a `API_HOST` env var to `https://api.[dev|feature|beta].nrfcloud.com` (you will need an AWS account for that environment). You can also set the `API_HOST` env var to the url of your sub account (ie `https://api.<user_id>.nrfcloud.com`) and the `stage` will be automatically set to `dev` (the stage is used for the job subscription topics for FOTA). You no longer need to set a `STAGE` variable, and it will be ignored.
-
 This will create a new device with AWS IoT, but it will not onboard it to your account (use the `-a preconnect` flag) for that.
 ```
 npx @nrfcloud/device-simulator-v2 -k <api key> [-d <desired device ID>] -t atv2

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ You can name the device whatever you want with the `-d` option. If not present, 
 ### Associate device to your account
 This will create a new device and associate it to the account for the API key.
 ```
-npx @nrfcloud/device-simulator-v2 -k <api key> -a -t atv2
+npx @nrfcloud/device-simulator-v2 -k <api key> -a -t atv2 -a preconnect
 ```
 
 ### Simulate sensor outputs
 Include any combination of the options listed after `-s` below:
 ```
-npx @nrfcloud/device-simulator-v2 -k <api key> -a -d <device ID you already associated> -s gps,acc,device,temp
+npx @nrfcloud/device-simulator-v2 -k <api key> -a preconnect -d <device ID you already onboarded> -s gps,acc,device,temp
 ```
-*Note! Usually the `-a` is not necessary, since the device is already associated to your account. However, due to bug IRIS-3450, this does not always work. Adding the `-a` is harmless and is a workaround for now.*
+*Note! Usually the `-a` is not necessary, since the device is already onboarded to your account. However, due to bug IRIS-3450, this does not always work. Adding the `-a` is harmless and is a workaround for now.*
 
 *Note! Including `device` in the list will generate a LOT of device info messages which may overrun your Web browser. Best not to run it more than a few seconds with it, or you can leave out `device` and run it long-term.*
 
@@ -55,7 +55,7 @@ These are the options. Most of them are set with environment variables.
   -k, --api-key <apiKey> (required)                  API key for nRF Cloud (default: "")
   -h, --api-host <apiHost>                           API host for nRF Cloud (default: "https://api.nrfcloud.com")
   -d, --device-id <deviceId>                         ID of the device (default: <nrfsim-randomString>)
-  -a, --associate                                    Automatically associate device to your account (default: false)
+  -a, --onboard <onboardingType>                     Onboard the device with "jitp", or "preconnect"
   -s, --services <services>                          Comma-delimited list of services to enable. Any of: [gps,acc,temp,device,rsrp,location,log,alert]
   -f, --app-fw-version <appFwVersion>                Version of the app firmware (default: 1)
   -c, --certs-response <certsResponse>               JSON returned by call POST /devices/{deviceid}/certificates (default: "")
@@ -238,7 +238,7 @@ MESSAGE: {
 }
 ***************************************
 
-Cannot initialize jobs listener until the device "<your_device_id>" is associated to your account. You can associate the device by running "npx @nrfcloud/device-simulator-v2 -k <api key> -d <your_device_id> -a".
+Cannot initialize jobs listener until the device "<your_device_id>" is onboarded to your account. You can onboard the device by running "npx @nrfcloud/device-simulator-v2 -k <api key> -d <your_device_id> -a preconnect".
 ```
 
 This indicates that the device provisioned with AWS and updated its shadow.
@@ -261,7 +261,7 @@ node dist/cli.js
 ```
 You should see this JSON output: 
 ```sh
-confirmed that "<your_device_id>" has been associated with account "<your_tenant_id>"!
+confirmed that "<your_device_id>" has been onboarded with account "<your_tenant_id>"!
 
 listening for new jobs...
 
@@ -275,7 +275,7 @@ MESSAGE: [
 subscribed to "dev/<your_tenant_id>/<your_device_id>/jobs/rcv"
 ```
 
-Your device is now associated with your account (tenant) and is ready to start sending and receiving device messages! It is also listening for new FOTA jobs. 
+Your device is now onboarded with your account (tenant) and is ready to start sending and receiving device messages! It is also listening for new FOTA jobs. 
 
 ### Create a new Firmware Over-the-Air (FOTA) job
 1. Open a new terminal window/tab.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The most basic usage is just creating a device. For that you just need an API ke
 
 The host defaults to the production environment (https://api.nrfcloud.com). **Nordic Semiconductor personnel**: if you want to use the simulator on our `dev`, `feature`, or `beta` environments, set a `API_HOST` env var to `https://api.[dev|feature|beta].nrfcloud.com` (you will need an AWS account for that environment). You can also set the `API_HOST` env var to the url of your sub account (ie `https://api.<user_id>.nrfcloud.com`) and the `stage` will be automatically set to `dev` (the stage is used for the job subscription topics for FOTA). You no longer need to set a `STAGE` variable, and it will be ignored.
 
-This will create a new device with AWS IoT, but it will not associate it to your account (use the `-a` flag) for that.
+This will create a new device with AWS IoT, but it will not onboard it to your account (use the `-a preconnect` flag) for that.
 ```
 npx @nrfcloud/device-simulator-v2 -k <api key> [-d <desired device ID>] -t atv2
 ```
@@ -21,19 +21,17 @@ If you would like to use the local code instead of npx, first run `yarn && yarn 
 
 You can name the device whatever you want with the `-d` option. If not present, it will be named `nrfsim-<random 21 digits>`.
 
-### Associate device to your account
-This will create a new device and associate it to the account for the API key.
+### Onboard a device to your account
+This example will onboard a device to nRF Cloud by creating a new simulated device and associating it to the user's team. The user's API key authenticates the REST request. A default device shadow will be created in the style of the Asset Tracker v2 (atv2) sample firmware. For the pre-connect mode of onboarding, the device simulator will create and provide self-signed certificates in the onboarding process.
 ```
-npx @nrfcloud/device-simulator-v2 -k <api key> -a -t atv2 -a preconnect
+npx @nrfcloud/device-simulator-v2 -k <api key> -t atv2 -a preconnect
 ```
 
 ### Simulate sensor outputs
-Include any combination of the options listed after `-s` below:
+After creating and onboarding your device, you can include any combination of the options listed after `-s` below, to simulate the device sending messages containing device sensor data:
 ```
-npx @nrfcloud/device-simulator-v2 -k <api key> -a preconnect -d <device ID you already onboarded> -s gps,acc,device,temp
+npx @nrfcloud/device-simulator-v2 -k <api key> -d <device ID you already onboarded> -s gps,acc,device,temp
 ```
-*Note! Usually the `-a` is not necessary, since the device is already onboarded to your account. However, due to bug IRIS-3450, this does not always work. Adding the `-a` is harmless and is a workaround for now.*
-
 *Note! Including `device` in the list will generate a LOT of device info messages which may overrun your Web browser. Best not to run it more than a few seconds with it, or you can leave out `device` and run it long-term.*
 
 *Note! The `acc` option sends FLIP accelerometer messages, simulating the device being flipped right-side-up or upside-down. This was a feature of the Asset Tracker v1 firmware example that has been removed for the currently supported Asset Tracker v2.*
@@ -43,7 +41,7 @@ If you want to use different GPS data, replace the appropriate file in [./data/s
 GPS data is based on NMEA sentences. If you want to make your own GPS data, go to https://nmeagen.org. The "Multi-point line" seems to work best. Lay some points and then click the "Generate NMEA file" button.
 
 ### Do it all at once
-You can create a new simulated device, associate it, and start sending sensor data all in one command, which is a typical way to use the simulator:
+You can create a new simulated device, onboard it, and start sending sensor data all in one command, which is a typical way to use the simulator:
 ```
 npx @nrfcloud/device-simulator-v2 -k <api key> [-d <desired device ID>] -a -s gps,acc,device,temp
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,7 @@ const handleJobExecution = (input: string, _: unknown) => {
 };
 
 const handleOnboardingType = (input: string, _: unknown) => {
+  console.debug('input', input);
   if (typeof input === 'undefined' || input === 'onboard') {
     return 'onboard';
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,16 +74,12 @@ const handleJobExecution = (input: string, _: unknown) => {
 };
 
 const handleOnboardingType = (input: string, _: unknown) => {
-  if (input === 'preconnect') {
-    return 'preconnect';
-  }
-
-  if (input === 'jitp') {
+  if (input === 'preconnect' || input === 'jitp') {
     return input;
   }
 
   new Log(false).error(
-    'Input for associate must be blank, "jitp" or "preconnect"',
+    'Input for onboard must be blank, "jitp" or "preconnect"',
   );
   process.exit();
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,8 +74,8 @@ const handleJobExecution = (input: string, _: unknown) => {
 };
 
 const handleOnboardingType = (input: string, _: unknown) => {
-  if (input === 'onboard') {
-    return 'onboard';
+  if (input === 'preconnect') {
+    return 'preconnect';
   }
 
   if (input === 'jitp') {
@@ -83,7 +83,7 @@ const handleOnboardingType = (input: string, _: unknown) => {
   }
 
   new Log(false).error(
-    'Input for associate must be blank, "jitp" or "onboard"',
+    'Input for associate must be blank, "jitp" or "preconnect"',
   );
   process.exit();
 };
@@ -131,8 +131,8 @@ const getConfig = (env: any, args: string[]): SimulatorConfig =>
       env.API_HOST ? env.API_HOST : 'https://api.nrfcloud.com',
     )
     .option(
-      '-a, --associate <associationType>',
-      'automatically onboard device to account, to associate with JITP use the "jitp" flag',
+      '-a, --onboard <onboardingType>',
+      'Onboard the device with "jitp", or "preconnect"',
       handleOnboardingType,
     )
     .option('-v, --verbose', 'output debug info', false)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,162 +7,162 @@ import { Log } from './models/Log';
 import { SimulatorConfig, run } from './index';
 
 function validateAppTypeJSONInput(input: any) {
-	if (typeof input.state !== 'object') {
-		new Log(false).error(
-			'appType custom shadow is missing object value for "state" key',
-		);
-		return false;
-	}
+  if (typeof input.state !== 'object') {
+    new Log(false).error(
+      'appType custom shadow is missing object value for "state" key',
+    );
+    return false;
+  }
 
-	if (typeof input.state.reported !== 'object') {
-		new Log(false).error(
-			'appType custom shadow "state" object is missing object value for "reported" key',
-		);
-		return false;
-	}
+  if (typeof input.state.reported !== 'object') {
+    new Log(false).error(
+      'appType custom shadow "state" object is missing object value for "reported" key',
+    );
+    return false;
+  }
 
-	return true;
+  return true;
 }
 
 const handleAppType = async (input: any, _: unknown) => {
-	if (input === 'mss' || input === 'atv2') {
-		return input;
-	}
+  if (input === 'mss' || input === 'atv2') {
+    return input;
+  }
 
-	if (input[0] !== '[' && input[0] !== '{' && !input.includes('.json')) {
-		new Log(false).error(
-			'Input for appType may only be "mss", "atv2", JSON-encoded object, or path to a json file.',
-		);
-		process.exit();
-	}
+  if (input[0] !== '[' && input[0] !== '{' && !input.includes('.json')) {
+    new Log(false).error(
+      'Input for appType may only be "mss", "atv2", JSON-encoded object, or path to a json file.',
+    );
+    process.exit();
+  }
 
-	if (input.includes('.json')) {
-		//Adding an additional '../' to the input since it's being called from dist and not src
-		const file = path.join(__dirname, '../' + input);
-		try {
-			input = await readFile(file, 'utf8');
-		} catch (err) {
-			new Log(false).error(`Error opening file: ${err}`);
-			process.exit();
-		}
-	}
+  if (input.includes('.json')) {
+    //Adding an additional '../' to the input since it's being called from dist and not src
+    const file = path.join(__dirname, '../' + input);
+    try {
+      input = await readFile(file, 'utf8');
+    } catch (err) {
+      new Log(false).error(`Error opening file: ${err}`);
+      process.exit();
+    }
+  }
 
-	try {
-		input = JSON.parse(input);
-		if (!validateAppTypeJSONInput(input)) {
-			new Log(false).info(
-				`Expected input: '{"state":{"reported":{...}, "desired":{...}}}', "desired" is optional.`,
-			);
-			process.exit();
-		}
-	} catch (err) {
-		new Log(false).error('Error parsing JSON:' + (err as any).message);
-		process.exit();
-	}
-	return input;
+  try {
+    input = JSON.parse(input);
+    if (!validateAppTypeJSONInput(input)) {
+      new Log(false).info(
+        `Expected input: '{"state":{"reported":{...}, "desired":{...}}}', "desired" is optional.`,
+      );
+      process.exit();
+    }
+  } catch (err) {
+    new Log(false).error('Error parsing JSON:' + (err as any).message);
+    process.exit();
+  }
+  return input;
 };
 
 const handleJobExecution = (input: string, _: unknown) => {
-	const validPath = /^[0-5]$/;
-	if (!validPath.test(input)) {
-		new Log(false).error(
-			'Input for jobExecutionPath must be a number between 0 and 5',
-		);
-		process.exit();
-	}
-	return input;
+  const validPath = /^[0-5]$/;
+  if (!validPath.test(input)) {
+    new Log(false).error(
+      'Input for jobExecutionPath must be a number between 0 and 5',
+    );
+    process.exit();
+  }
+  return input;
 };
 
 const handleOnboardingType = (input: string, _: unknown) => {
-	if (typeof input === 'undefined' || input === 'onboard') {
-		return 'onboard';
-	}
+  if (typeof input === 'undefined' || input === 'onboard') {
+    return 'onboard';
+  }
 
-	if (input === 'jitp') {
-		return input;
-	}
+  if (input === 'jitp') {
+    return input;
+  }
 
-	new Log(false).error(
-		'Input for associate must be blank, "jitp" or "onboard"',
-	);
-	process.exit();
+  new Log(false).error(
+    'Input for associate must be blank, "jitp" or "onboard"',
+  );
+  process.exit();
 };
 
 const getConfig = (env: any, args: string[]): SimulatorConfig =>
-	program
-		.requiredOption(
-			'-k, --api-key <apiKey>',
-			'API key for nRF Cloud',
-			env.API_KEY,
-		)
-		.option(
-			'-c, --certs-response <certsResponse>',
-			'JSON returned by call to the Device API endpoint: POST /devices/{deviceid}/certificates',
-			env.CERTS_RESPONSE,
-		)
-		.option(
-			'-e, --endpoint <endpoint>',
-			'AWS IoT MQTT endpoint',
-			env.MQTT_ENDPOINT,
-		)
-		.option('-d, --device-id <deviceId>', 'ID of the device', env.DEVICE_ID)
-		.option(
-			'-o, --device-ownership-code <deviceOwnershipCode>',
-			'PIN/ownership code of the device',
-			env.DEVICE_OWNERSHIP_CODE || '123456',
-		)
-		.option(
-			'-m, --mqtt-messages-prefix <mqttMessagesPrefix>',
-			'The prefix for the MQTT unique to this tenant for sending and receiving device messages',
-			env.MQTT_MESSAGES_PREFIX,
-		)
-		.option(
-			'-s, --services <services>',
-			'Comma-delimited list of services to enable. Any of: [gps,acc,temp,device,rsrp,location,log,alert]',
-		)
-		.option(
-			'-f, --app-fw-version <appFwVersion>',
-			'Version of the app firmware',
-			'1',
-		)
-		.option(
-			'-h, --api-host <apiHost>',
-			'API host for nRF Cloud',
-			env.API_HOST ? env.API_HOST : 'https://api.nrfcloud.com',
-		)
-		.option(
-			'-a, --associate',
-			'automatically onboard device to account, to associate with JITP use the "jitp" flag',
-			handleOnboardingType,
-		)
-		.option('-v, --verbose', 'output debug info', false)
-		.option(
-			'-t, --app-type <appType>',
-			'Specifies the shadow to use. For custom shadow, pass a JSON-encoded shadow object or relative path to json file. Otherwise, pass "mss" or "atv2" to automatically generate a conformal shadow',
-			handleAppType,
-		)
-		.option(
-			'-p, --job-execution-path <jobExecutionPath>',
-			'Specifies an unhappy job execution path for a fota update. View the "Use an unhappy path for FOTA execution" section of the README for more details.',
-			handleJobExecution,
-		)
-		.parse(args)
-		.opts() as SimulatorConfig;
+  program
+    .requiredOption(
+      '-k, --api-key <apiKey>',
+      'API key for nRF Cloud',
+      env.API_KEY,
+    )
+    .option(
+      '-c, --certs-response <certsResponse>',
+      'JSON returned by call to the Device API endpoint: POST /devices/{deviceid}/certificates',
+      env.CERTS_RESPONSE,
+    )
+    .option(
+      '-e, --endpoint <endpoint>',
+      'AWS IoT MQTT endpoint',
+      env.MQTT_ENDPOINT,
+    )
+    .option('-d, --device-id <deviceId>', 'ID of the device', env.DEVICE_ID)
+    .option(
+      '-o, --device-ownership-code <deviceOwnershipCode>',
+      'PIN/ownership code of the device',
+      env.DEVICE_OWNERSHIP_CODE || '123456',
+    )
+    .option(
+      '-m, --mqtt-messages-prefix <mqttMessagesPrefix>',
+      'The prefix for the MQTT unique to this tenant for sending and receiving device messages',
+      env.MQTT_MESSAGES_PREFIX,
+    )
+    .option(
+      '-s, --services <services>',
+      'Comma-delimited list of services to enable. Any of: [gps,acc,temp,device,rsrp,location,log,alert]',
+    )
+    .option(
+      '-f, --app-fw-version <appFwVersion>',
+      'Version of the app firmware',
+      '1',
+    )
+    .option(
+      '-h, --api-host <apiHost>',
+      'API host for nRF Cloud',
+      env.API_HOST ? env.API_HOST : 'https://api.nrfcloud.com',
+    )
+    .option(
+      '-a, --associate',
+      'automatically onboard device to account, to associate with JITP use the "jitp" flag',
+      handleOnboardingType,
+    )
+    .option('-v, --verbose', 'output debug info', false)
+    .option(
+      '-t, --app-type <appType>',
+      'Specifies the shadow to use. For custom shadow, pass a JSON-encoded shadow object or relative path to json file. Otherwise, pass "mss" or "atv2" to automatically generate a conformal shadow',
+      handleAppType,
+    )
+    .option(
+      '-p, --job-execution-path <jobExecutionPath>',
+      'Specifies an unhappy job execution path for a fota update. View the "Use an unhappy path for FOTA execution" section of the README for more details.',
+      handleJobExecution,
+    )
+    .parse(args)
+    .opts() as SimulatorConfig;
 
 let verbose: boolean;
 
 (async (): Promise<void> => {
-	const config = getConfig(process.env, process.argv);
-	verbose = !!config.verbose;
-	const hostSplit = config.apiHost!.split('.');
-	let stage = hostSplit.length === 3 ? 'prod' : hostSplit[1];
+  const config = getConfig(process.env, process.argv);
+  verbose = !!config.verbose;
+  const hostSplit = config.apiHost!.split('.');
+  let stage = hostSplit.length === 3 ? 'prod' : hostSplit[1];
 
-	// dev is default stage for sub accounts (ie https://api.coha.nrfcloud.com)
-	if (['dev', 'beta', 'prod'].includes(stage) === false) {
-		stage = 'dev';
-	}
+  // dev is default stage for sub accounts (ie https://api.coha.nrfcloud.com)
+  if (['dev', 'beta', 'prod'].includes(stage) === false) {
+    stage = 'dev';
+  }
 
-	config.stage = stage;
-	config.appType = await config.appType;
-	return run(config);
+  config.stage = stage;
+  config.appType = await config.appType;
+  return run(config);
 })().catch((err) => new Log(verbose).error(err));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,147 +7,162 @@ import { Log } from './models/Log';
 import { SimulatorConfig, run } from './index';
 
 function validateAppTypeJSONInput(input: any) {
-  if (typeof input.state !== 'object') {
-    new Log(false).error(
-      'appType custom shadow is missing object value for "state" key',
-    );
-    return false;
-  }
+	if (typeof input.state !== 'object') {
+		new Log(false).error(
+			'appType custom shadow is missing object value for "state" key',
+		);
+		return false;
+	}
 
-  if (typeof input.state.reported !== 'object') {
-    new Log(false).error(
-      'appType custom shadow "state" object is missing object value for "reported" key',
-    );
-    return false;
-  }
+	if (typeof input.state.reported !== 'object') {
+		new Log(false).error(
+			'appType custom shadow "state" object is missing object value for "reported" key',
+		);
+		return false;
+	}
 
-  return true;
+	return true;
 }
 
 const handleAppType = async (input: any, _: unknown) => {
-  if (input === 'mss' || input === 'atv2') {
-    return input;
-  }
+	if (input === 'mss' || input === 'atv2') {
+		return input;
+	}
 
-  if (input[0] !== '[' && input[0] !== '{' && !input.includes('.json')) {
-    new Log(false).error(
-      'Input for appType may only be "mss", "atv2", JSON-encoded object, or path to a json file.',
-    );
-    process.exit();
-  }
+	if (input[0] !== '[' && input[0] !== '{' && !input.includes('.json')) {
+		new Log(false).error(
+			'Input for appType may only be "mss", "atv2", JSON-encoded object, or path to a json file.',
+		);
+		process.exit();
+	}
 
-  if (input.includes('.json')) {
-    //Adding an additional '../' to the input since it's being called from dist and not src
-    const file = path.join(__dirname, '../' + input);
-    try {
-      input = await readFile(file, 'utf8');
-    } catch (err) {
-      new Log(false).error(`Error opening file: ${err}`);
-      process.exit();
-    }
-  }
+	if (input.includes('.json')) {
+		//Adding an additional '../' to the input since it's being called from dist and not src
+		const file = path.join(__dirname, '../' + input);
+		try {
+			input = await readFile(file, 'utf8');
+		} catch (err) {
+			new Log(false).error(`Error opening file: ${err}`);
+			process.exit();
+		}
+	}
 
-  try {
-    input = JSON.parse(input);
-    if (!validateAppTypeJSONInput(input)) {
-      new Log(false).info(
-        `Expected input: '{"state":{"reported":{...}, "desired":{...}}}', "desired" is optional.`,
-      );
-      process.exit();
-    }
-  } catch (err) {
-    new Log(false).error('Error parsing JSON:' + (err as any).message);
-    process.exit();
-  }
-  return input;
+	try {
+		input = JSON.parse(input);
+		if (!validateAppTypeJSONInput(input)) {
+			new Log(false).info(
+				`Expected input: '{"state":{"reported":{...}, "desired":{...}}}', "desired" is optional.`,
+			);
+			process.exit();
+		}
+	} catch (err) {
+		new Log(false).error('Error parsing JSON:' + (err as any).message);
+		process.exit();
+	}
+	return input;
 };
 
 const handleJobExecution = (input: string, _: unknown) => {
-  const validPath = /^[0-5]$/;
-  if (!validPath.test(input)) {
-    new Log(false).error(
-      'Input for jobExecutionPath must be a number between 0 and 5',
-    );
-    process.exit();
-  }
-  return input;
+	const validPath = /^[0-5]$/;
+	if (!validPath.test(input)) {
+		new Log(false).error(
+			'Input for jobExecutionPath must be a number between 0 and 5',
+		);
+		process.exit();
+	}
+	return input;
+};
+
+const handleOnboardingType = (input: string, _: unknown) => {
+	if (typeof input === 'undefined' || input === 'onboard') {
+		return 'onboard';
+	}
+
+	if (input === 'jitp') {
+		return input;
+	}
+
+	new Log(false).error(
+		'Input for associate must be blank, "jitp" or "onboard"',
+	);
+	process.exit();
 };
 
 const getConfig = (env: any, args: string[]): SimulatorConfig =>
-  program
-    .requiredOption(
-      '-k, --api-key <apiKey>',
-      'API key for nRF Cloud',
-      env.API_KEY,
-    )
-    .option(
-      '-c, --certs-response <certsResponse>',
-      'JSON returned by call to the Device API endpoint: POST /devices/{deviceid}/certificates',
-      env.CERTS_RESPONSE,
-    )
-    .option(
-      '-e, --endpoint <endpoint>',
-      'AWS IoT MQTT endpoint',
-      env.MQTT_ENDPOINT,
-    )
-    .option('-d, --device-id <deviceId>', 'ID of the device', env.DEVICE_ID)
-    .option(
-      '-o, --device-ownership-code <deviceOwnershipCode>',
-      'PIN/ownership code of the device',
-      env.DEVICE_OWNERSHIP_CODE || '123456',
-    )
-    .option(
-      '-m, --mqtt-messages-prefix <mqttMessagesPrefix>',
-      'The prefix for the MQTT unique to this tenant for sending and receiving device messages',
-      env.MQTT_MESSAGES_PREFIX,
-    )
-    .option(
-      '-s, --services <services>',
-      'Comma-delimited list of services to enable. Any of: [gps,acc,temp,device,rsrp,location,log,alert]',
-    )
-    .option(
-      '-f, --app-fw-version <appFwVersion>',
-      'Version of the app firmware',
-      '1',
-    )
-    .option(
-      '-h, --api-host <apiHost>',
-      'API host for nRF Cloud',
-      env.API_HOST ? env.API_HOST : 'https://api.nrfcloud.com',
-    )
-    .option(
-      '-a, --associate',
-      'automatically associate device to account',
-      false,
-    )
-    .option('-v, --verbose', 'output debug info', false)
-    .option(
-      '-t, --app-type <appType>',
-      'Specifies the shadow to use. For custom shadow, pass a JSON-encoded shadow object or relative path to json file. Otherwise, pass "mss" or "atv2" to automatically generate a conformal shadow',
-      handleAppType,
-    )
-    .option(
-      '-p, --job-execution-path <jobExecutionPath>',
-      'Specifies an unhappy job execution path for a fota update. View the "Use an unhappy path for FOTA execution" section of the README for more details.',
-      handleJobExecution,
-    )
-    .parse(args)
-    .opts() as SimulatorConfig;
+	program
+		.requiredOption(
+			'-k, --api-key <apiKey>',
+			'API key for nRF Cloud',
+			env.API_KEY,
+		)
+		.option(
+			'-c, --certs-response <certsResponse>',
+			'JSON returned by call to the Device API endpoint: POST /devices/{deviceid}/certificates',
+			env.CERTS_RESPONSE,
+		)
+		.option(
+			'-e, --endpoint <endpoint>',
+			'AWS IoT MQTT endpoint',
+			env.MQTT_ENDPOINT,
+		)
+		.option('-d, --device-id <deviceId>', 'ID of the device', env.DEVICE_ID)
+		.option(
+			'-o, --device-ownership-code <deviceOwnershipCode>',
+			'PIN/ownership code of the device',
+			env.DEVICE_OWNERSHIP_CODE || '123456',
+		)
+		.option(
+			'-m, --mqtt-messages-prefix <mqttMessagesPrefix>',
+			'The prefix for the MQTT unique to this tenant for sending and receiving device messages',
+			env.MQTT_MESSAGES_PREFIX,
+		)
+		.option(
+			'-s, --services <services>',
+			'Comma-delimited list of services to enable. Any of: [gps,acc,temp,device,rsrp,location,log,alert]',
+		)
+		.option(
+			'-f, --app-fw-version <appFwVersion>',
+			'Version of the app firmware',
+			'1',
+		)
+		.option(
+			'-h, --api-host <apiHost>',
+			'API host for nRF Cloud',
+			env.API_HOST ? env.API_HOST : 'https://api.nrfcloud.com',
+		)
+		.option(
+			'-a, --associate',
+			'automatically onboard device to account, to associate with JITP use the "jitp" flag',
+			handleOnboardingType,
+		)
+		.option('-v, --verbose', 'output debug info', false)
+		.option(
+			'-t, --app-type <appType>',
+			'Specifies the shadow to use. For custom shadow, pass a JSON-encoded shadow object or relative path to json file. Otherwise, pass "mss" or "atv2" to automatically generate a conformal shadow',
+			handleAppType,
+		)
+		.option(
+			'-p, --job-execution-path <jobExecutionPath>',
+			'Specifies an unhappy job execution path for a fota update. View the "Use an unhappy path for FOTA execution" section of the README for more details.',
+			handleJobExecution,
+		)
+		.parse(args)
+		.opts() as SimulatorConfig;
 
 let verbose: boolean;
 
 (async (): Promise<void> => {
-  const config = getConfig(process.env, process.argv);
-  verbose = !!config.verbose;
-  const hostSplit = config.apiHost!.split('.');
-  let stage = hostSplit.length === 3 ? 'prod' : hostSplit[1];
+	const config = getConfig(process.env, process.argv);
+	verbose = !!config.verbose;
+	const hostSplit = config.apiHost!.split('.');
+	let stage = hostSplit.length === 3 ? 'prod' : hostSplit[1];
 
-  // dev is default stage for sub accounts (ie https://api.coha.nrfcloud.com)
-  if (['dev', 'beta', 'prod'].includes(stage) === false) {
-    stage = 'dev';
-  }
+	// dev is default stage for sub accounts (ie https://api.coha.nrfcloud.com)
+	if (['dev', 'beta', 'prod'].includes(stage) === false) {
+		stage = 'dev';
+	}
 
-  config.stage = stage;
-  config.appType = await config.appType;
-  return run(config);
+	config.stage = stage;
+	config.appType = await config.appType;
+	return run(config);
 })().catch((err) => new Log(verbose).error(err));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,8 +74,7 @@ const handleJobExecution = (input: string, _: unknown) => {
 };
 
 const handleOnboardingType = (input: string, _: unknown) => {
-  console.debug('input', input);
-  if (typeof input === 'undefined' || input === 'onboard') {
+  if (input === 'onboard') {
     return 'onboard';
   }
 
@@ -132,7 +131,7 @@ const getConfig = (env: any, args: string[]): SimulatorConfig =>
       env.API_HOST ? env.API_HOST : 'https://api.nrfcloud.com',
     )
     .option(
-      '-a, --associate',
+      '-a, --associate <associationType>',
       'automatically onboard device to account, to associate with JITP use the "jitp" flag',
       handleOnboardingType,
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,7 @@ export const getDefaults = async ({
 
   if (!certsResponse) {
     log.debug('Grabbing cert...');
+    console.debug('cachedDefaults', cachedDefaults);
     let defaultJsonCert = cachedDefaults.certsResponse || '';
 
     if (!defaultJsonCert) {
@@ -154,6 +155,7 @@ export const getDefaults = async ({
         defaultJsonCert = JSON.stringify(data);
       } else {
         log.debug('Generating self signed device certs.\n');
+        console.debug('Are we creating new certs?');
 
         const privateKey = execSync(
           `openssl ecparam -name prime256v1 -genkey`,
@@ -259,7 +261,6 @@ export const run = async (config: SimulatorConfig): Promise<void> => {
     ]),
   );
 
-  console.debug(associate);
   const defaults: DeviceDefaults = await getDefaults({
     deviceId: config.deviceId,
     deviceOwnershipCode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,245 +9,245 @@ const cache = require('ez-cache')();
 let conn: AxiosInstance;
 
 export const getConn = (
-	apiHost: string,
-	apiKey: string,
-	verbose: boolean,
+  apiHost: string,
+  apiKey: string,
+  verbose: boolean,
 ): AxiosInstance => {
-	if (!conn) {
-		// create a connection to the device API
-		conn = axios.create({
-			baseURL: apiHost,
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				'Content-Type': 'text/plain',
-			},
-		});
+  if (!conn) {
+    // create a connection to the device API
+    conn = axios.create({
+      baseURL: apiHost,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'text/plain',
+      },
+    });
 
-		conn.interceptors.request.use((config: any) => {
-			new Log(!!verbose).debug(config);
-			return config;
-		});
-	}
+    conn.interceptors.request.use((config: any) => {
+      new Log(!!verbose).debug(config);
+      return config;
+    });
+  }
 
-	return conn;
+  return conn;
 };
 
 export const generateDeviceId = () =>
-	`nrfsim-${Math.floor(Math.random() * 1000000000000000000000)}`;
+  `nrfsim-${Math.floor(Math.random() * 1000000000000000000000)}`;
 
 export type DeviceDefaults = {
-	endpoint: string;
-	mqttMessagesPrefix: string;
-	certsResponse: string;
-	tenantId: string;
+  endpoint: string;
+  mqttMessagesPrefix: string;
+  certsResponse: string;
+  tenantId: string;
 };
 
 export type SimulatorConfig = {
-	certsResponse: string;
-	endpoint: string;
-	appFwVersion: string;
-	deviceId: string;
-	mqttMessagesPrefix: string;
-	stage: string;
-	tenantId: string;
-	appType: string;
-	services?: string;
-	apiKey?: string;
-	apiHost?: string;
-	deviceOwnershipCode?: string;
-	verbose?: boolean;
-	associate?: string;
-	jobExecutionPath?: any;
-	onConnect?: (deviceId: string, client?: device) => Promise<void>;
+  certsResponse: string;
+  endpoint: string;
+  appFwVersion: string;
+  deviceId: string;
+  mqttMessagesPrefix: string;
+  stage: string;
+  tenantId: string;
+  appType: string;
+  services?: string;
+  apiKey?: string;
+  apiHost?: string;
+  deviceOwnershipCode?: string;
+  verbose?: boolean;
+  associate?: string;
+  jobExecutionPath?: any;
+  onConnect?: (deviceId: string, client?: device) => Promise<void>;
 };
 
 export const associateDevice = ({
-	deviceId,
-	deviceOwnershipCode,
-	apiHost,
-	apiKey,
-	verbose,
+  deviceId,
+  deviceOwnershipCode,
+  apiHost,
+  apiKey,
+  verbose,
 }: Partial<SimulatorConfig>): Promise<void> =>
-	getConn(apiHost as string, apiKey as string, !!verbose).put(
-		`/v1/association/${deviceId}`,
-		deviceOwnershipCode,
-	);
+  getConn(apiHost as string, apiKey as string, !!verbose).put(
+    `/v1/association/${deviceId}`,
+    deviceOwnershipCode,
+  );
 
 export const getDefaults = async ({
-	deviceId,
-	endpoint,
-	mqttMessagesPrefix,
-	certsResponse,
-	apiHost,
-	apiKey,
-	deviceOwnershipCode,
-	verbose,
-	associate,
+  deviceId,
+  endpoint,
+  mqttMessagesPrefix,
+  certsResponse,
+  apiHost,
+  apiKey,
+  deviceOwnershipCode,
+  verbose,
+  associate,
 }: Partial<SimulatorConfig>): Promise<DeviceDefaults> => {
-	const conn = getConn(apiHost!, apiKey!, !!verbose);
-	const log = new Log(!!verbose);
+  const conn = getConn(apiHost!, apiKey!, !!verbose);
+  const log = new Log(!!verbose);
 
-	const defaults: DeviceDefaults = {
-		endpoint: endpoint || '',
-		mqttMessagesPrefix: mqttMessagesPrefix || '',
-		certsResponse: certsResponse || '',
-		tenantId: '',
-	};
+  const defaults: DeviceDefaults = {
+    endpoint: endpoint || '',
+    mqttMessagesPrefix: mqttMessagesPrefix || '',
+    certsResponse: certsResponse || '',
+    tenantId: '',
+  };
 
-	const cacheFile = cache.getFilePath(deviceId);
+  const cacheFile = cache.getFilePath(deviceId);
 
-	const cachedDefaults: DeviceDefaults = cache.exists(cacheFile)
-		? await cache.get(cacheFile)
-		: {};
+  const cachedDefaults: DeviceDefaults = cache.exists(cacheFile)
+    ? await cache.get(cacheFile)
+    : {};
 
-	if (!(endpoint && mqttMessagesPrefix)) {
-		log.debug(`Grabbing mqttEndpoint and messagesPrefix...`);
-		let defaultEndpoint = cachedDefaults.endpoint || '',
-			defaultMqttMessagesPrefix = cachedDefaults.mqttMessagesPrefix || '';
+  if (!(endpoint && mqttMessagesPrefix)) {
+    log.debug(`Grabbing mqttEndpoint and messagesPrefix...`);
+    let defaultEndpoint = cachedDefaults.endpoint || '',
+      defaultMqttMessagesPrefix = cachedDefaults.mqttMessagesPrefix || '';
 
-		if (!(defaultEndpoint && defaultMqttMessagesPrefix)) {
-			log.debug('Fetching endpoints from device API.\n');
-			const { data } = await conn.get(`/v1/account`);
-			defaultMqttMessagesPrefix = data.mqttTopicPrefix + 'm/';
-			defaultEndpoint = data.mqttEndpoint;
-		}
+    if (!(defaultEndpoint && defaultMqttMessagesPrefix)) {
+      log.debug('Fetching endpoints from device API.\n');
+      const { data } = await conn.get(`/v1/account`);
+      defaultMqttMessagesPrefix = data.mqttTopicPrefix + 'm/';
+      defaultEndpoint = data.mqttEndpoint;
+    }
 
-		if (!endpoint) {
-			defaults.endpoint = defaultEndpoint;
-		}
+    if (!endpoint) {
+      defaults.endpoint = defaultEndpoint;
+    }
 
-		if (!mqttMessagesPrefix) {
-			defaults.mqttMessagesPrefix = defaultMqttMessagesPrefix;
-		}
-	}
+    if (!mqttMessagesPrefix) {
+      defaults.mqttMessagesPrefix = defaultMqttMessagesPrefix;
+    }
+  }
 
-	if (!certsResponse) {
-		log.debug('Grabbing cert...');
-		let defaultJsonCert = cachedDefaults.certsResponse || '';
+  if (!certsResponse) {
+    log.debug('Grabbing cert...');
+    let defaultJsonCert = cachedDefaults.certsResponse || '';
 
-		// NATE: Add code here
-		if (!defaultJsonCert && associate !== 'jitp') {
-			log.debug('Fetching cert from device API.\n');
-			const { data } = await conn.post(
-				`/v1/devices/${deviceId}/certificates`,
-				deviceOwnershipCode,
-			);
+    // NATE: Add code here
+    if (!defaultJsonCert && associate !== 'jitp') {
+      log.debug('Fetching cert from device API.\n');
+      const { data } = await conn.post(
+        `/v1/devices/${deviceId}/certificates`,
+        deviceOwnershipCode,
+      );
 
-			defaultJsonCert = JSON.stringify(data);
-		}
+      defaultJsonCert = JSON.stringify(data);
+    }
 
-		defaults.certsResponse = defaultJsonCert;
-	}
+    defaults.certsResponse = defaultJsonCert;
+  }
 
-	let tenantId = defaults.mqttMessagesPrefix.split('/')[1];
+  let tenantId = defaults.mqttMessagesPrefix.split('/')[1];
 
-	if (!tenantId) {
-		const { data } = await conn.get(`/v1/account`);
-		tenantId = data.team.tenantId;
-	}
+  if (!tenantId) {
+    const { data } = await conn.get(`/v1/account`);
+    tenantId = data.team.tenantId;
+  }
 
-	if (!tenantId) {
-		throw new Error(
-			`Cannot continue without tenantId! defaults: ${JSON.stringify(defaults)}`,
-		);
-	}
+  if (!tenantId) {
+    throw new Error(
+      `Cannot continue without tenantId! defaults: ${JSON.stringify(defaults)}`,
+    );
+  }
 
-	defaults.tenantId = tenantId;
-	await cache.set(cacheFile, defaults);
-	return defaults;
+  defaults.tenantId = tenantId;
+  await cache.set(cacheFile, defaults);
+  return defaults;
 };
 
 export const run = async (config: SimulatorConfig): Promise<void> => {
-	const {
-		deviceId,
-		apiKey,
-		apiHost,
-		certsResponse,
-		endpoint,
-		mqttMessagesPrefix,
-		deviceOwnershipCode,
-		associate,
-		verbose,
-	} = config;
+  const {
+    deviceId,
+    apiKey,
+    apiHost,
+    certsResponse,
+    endpoint,
+    mqttMessagesPrefix,
+    deviceOwnershipCode,
+    associate,
+    verbose,
+  } = config;
 
-	const log = new Log(!!verbose);
-	config.deviceId = deviceId || generateDeviceId();
+  const log = new Log(!!verbose);
+  config.deviceId = deviceId || generateDeviceId();
 
-	// grab the defaults from the API
-	if (!(apiKey && apiHost)) {
-		log.error(
-			`ERROR: apiKey: (passed val: "${apiKey}") and apiHost (passed val: "${apiHost}") are required`,
-		);
-		return;
-	}
+  // grab the defaults from the API
+  if (!(apiKey && apiHost)) {
+    log.error(
+      `ERROR: apiKey: (passed val: "${apiKey}") and apiHost (passed val: "${apiHost}") are required`,
+    );
+    return;
+  }
 
-	log.debug(
-		log.prettify('INITIAL CONFIG', [
-			['DEVICE ID', config.deviceId],
-			['DEVICE PIN', config.deviceOwnershipCode!],
-			['API HOST', config.apiHost!],
-			['API KEY', config.apiKey!],
-			['TENANT ID', config.tenantId],
-			['STAGE', config.stage],
-		]),
-	);
+  log.debug(
+    log.prettify('INITIAL CONFIG', [
+      ['DEVICE ID', config.deviceId],
+      ['DEVICE PIN', config.deviceOwnershipCode!],
+      ['API HOST', config.apiHost!],
+      ['API KEY', config.apiKey!],
+      ['TENANT ID', config.tenantId],
+      ['STAGE', config.stage],
+    ]),
+  );
 
-	const defaults: DeviceDefaults = await getDefaults({
-		deviceId: config.deviceId,
-		deviceOwnershipCode,
-		mqttMessagesPrefix,
-		certsResponse,
-		endpoint,
-		apiHost,
-		apiKey,
-		verbose,
-		associate,
-	});
+  const defaults: DeviceDefaults = await getDefaults({
+    deviceId: config.deviceId,
+    deviceOwnershipCode,
+    mqttMessagesPrefix,
+    certsResponse,
+    endpoint,
+    apiHost,
+    apiKey,
+    verbose,
+    associate,
+  });
 
-	config.certsResponse = defaults.certsResponse;
-	config.mqttMessagesPrefix = defaults.mqttMessagesPrefix;
-	config.endpoint = defaults.endpoint;
-	config.tenantId = defaults.tenantId;
+  config.certsResponse = defaults.certsResponse;
+  config.mqttMessagesPrefix = defaults.mqttMessagesPrefix;
+  config.endpoint = defaults.endpoint;
+  config.tenantId = defaults.tenantId;
 
-	log.info(
-		log.prettify('CONFIG', [
-			['DEVICE ID', config.deviceId],
-			['DEVICE PIN', config.deviceOwnershipCode!],
-			['API HOST', config.apiHost!],
-			['API KEY', config.apiKey!],
-			['TENANT ID', config.tenantId],
-			['STAGE', config.stage],
-		]),
-	);
+  log.info(
+    log.prettify('CONFIG', [
+      ['DEVICE ID', config.deviceId],
+      ['DEVICE PIN', config.deviceOwnershipCode!],
+      ['API HOST', config.apiHost!],
+      ['API KEY', config.apiKey!],
+      ['TENANT ID', config.tenantId],
+      ['STAGE', config.stage],
+    ]),
+  );
 
-	log.success('starting simulator...');
+  log.success('starting simulator...');
 
-	if (associate) {
-		config.onConnect = async (deviceId) => {
-			log.info(
-				`ATTEMPTING TO ASSOCIATE ${config.deviceId} WITH API KEY ${config.apiKey} VIA ${config.apiHost}`,
-			);
+  if (associate) {
+    config.onConnect = async (deviceId) => {
+      log.info(
+        `ATTEMPTING TO ASSOCIATE ${config.deviceId} WITH API KEY ${config.apiKey} VIA ${config.apiHost}`,
+      );
 
-			// wait to ensure the device is available in AWS IoT so it can be associated
-			await new Promise((resolve) => setTimeout(resolve, 2000));
+      // wait to ensure the device is available in AWS IoT so it can be associated
+      await new Promise((resolve) => setTimeout(resolve, 2000));
 
-			try {
-				await associateDevice({
-					deviceId,
-					deviceOwnershipCode,
-					apiHost,
-					apiKey,
-					verbose,
-				});
+      try {
+        await associateDevice({
+          deviceId,
+          deviceOwnershipCode,
+          apiHost,
+          apiKey,
+          verbose,
+        });
 
-				log.success('DEVICE ASSOCIATED!');
-			} catch (err) {
-				log.error(`Failed to associate: ${err}`);
-			}
-		};
-	}
+        log.success('DEVICE ASSOCIATED!');
+      } catch (err) {
+        log.error(`Failed to associate: ${err}`);
+      }
+    };
+  }
 
-	simulator(config).catch((err) => {
-		log.error(err);
-	});
+  simulator(config).catch((err) => {
+    log.error(err);
+  });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { device } from 'aws-iot-device-sdk';
 import { AxiosInstance } from 'axios/index';
 import axios from 'axios';
+import { execSync } from 'child_process';
 
 import { simulator } from './simulator';
 import { Log } from './models/Log';
@@ -73,6 +74,19 @@ export const associateDevice = ({
     deviceOwnershipCode,
   );
 
+export const onboardDevice = ({
+	deviceId,
+	certsResponse,
+	apiHost,
+	apiKey,
+	verbose,
+}: Partial<SimulatorConfig>) => {
+	const certificate = JSON.parse(certsResponse as string).certificate;
+	return getConn(apiHost as string, apiKey as string, !!verbose).post(
+	`v1/devices/${deviceId}`, certificate
+)
+}
+
 export const getDefaults = async ({
   deviceId,
   endpoint,
@@ -126,14 +140,34 @@ export const getDefaults = async ({
     let defaultJsonCert = cachedDefaults.certsResponse || '';
 
     // NATE: Add code here
-    if (!defaultJsonCert && associate !== 'jitp') {
-      log.debug('Fetching cert from device API.\n');
-      const { data } = await conn.post(
-        `/v1/devices/${deviceId}/certificates`,
-        deviceOwnershipCode,
-      );
+    if (!defaultJsonCert) {
+			if (associate === 'jitp') {
+				log.debug('Fetching cert from device API.\n');
+				const { data } = await conn.post(
+					`/v1/devices/${deviceId}/certificates`,
+					deviceOwnershipCode,
+				);
+	
+				defaultJsonCert = JSON.stringify(data);
+			} else {
+				log.debug('Generating self signed device certs.\n');
+				const privateKey = execSync(`openssl ecparam -name prime256v1 -genkey`);
 
-      defaultJsonCert = JSON.stringify(data);
+				const subject = "/C=NO/ST=Norway/L=Trondheim/O=Nordic Semiconductor/OU=Test Devices"
+				const caCert = execSync(`echo "${privateKey}" | openssl req -x509 -extensions v3_ca -new -nodes -key /dev/stdin -sha256 -days 1024 -subj "${subject}"`);
+				console.debug('CA Cert', caCert);
+
+				let deviceCSR = execSync(`openssl ecparam -name prime256v1 -genkey`);
+				console.debug('ECC', deviceCSR);
+				deviceCSR = execSync(`echo "${deviceCSR}" | openssl pkcs8 -topk8 -nocrypt -in /dev/stdin`);
+				console.debug('Device PEM', deviceCSR);
+				deviceCSR = execSync(`echo "${deviceCSR}" | openssl req -new -key /dev/stdin -subj "${subject}/CN=${deviceId}"`);
+				console.debug('Device CSR', deviceCSR);
+				deviceCSR = execSync(`openssl x509 -req -in <(echo "${deviceCSR}") -CA <(echo "${caCert}") -CAkey <(echo"${privateKey}") -CAcreateserial -days 10950 -sha256`)
+				console.debug('Device Cert', deviceCSR);
+
+				defaultJsonCert = JSON.stringify({privateKey, caCert, certificate: deviceCSR})
+			}
     }
 
     defaults.certsResponse = defaultJsonCert;
@@ -225,20 +259,24 @@ export const run = async (config: SimulatorConfig): Promise<void> => {
   if (associate) {
     config.onConnect = async (deviceId) => {
       log.info(
-        `ATTEMPTING TO ASSOCIATE ${config.deviceId} WITH API KEY ${config.apiKey} VIA ${config.apiHost}`,
+        `ATTEMPTING TO ${associate === 'jitp'? 'ASSOCIATE': 'ONBOARD'} ${config.deviceId} WITH API KEY ${config.apiKey} VIA ${config.apiHost}`,
       );
 
       // wait to ensure the device is available in AWS IoT so it can be associated
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
       try {
-        await associateDevice({
-          deviceId,
-          deviceOwnershipCode,
-          apiHost,
-          apiKey,
-          verbose,
-        });
+				if (associate === 'jitp') {
+					await associateDevice({
+						deviceId,
+						deviceOwnershipCode,
+						apiHost,
+						apiKey,
+						verbose,
+					});
+				} else {
+					await onboardDevice({deviceId, apiHost, apiKey, certsResponse, verbose})
+				}
 
         log.success('DEVICE ASSOCIATED!');
       } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,242 +9,245 @@ const cache = require('ez-cache')();
 let conn: AxiosInstance;
 
 export const getConn = (
-  apiHost: string,
-  apiKey: string,
-  verbose: boolean,
+	apiHost: string,
+	apiKey: string,
+	verbose: boolean,
 ): AxiosInstance => {
-  if (!conn) {
-    // create a connection to the device API
-    conn = axios.create({
-      baseURL: apiHost,
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'text/plain',
-      },
-    });
+	if (!conn) {
+		// create a connection to the device API
+		conn = axios.create({
+			baseURL: apiHost,
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				'Content-Type': 'text/plain',
+			},
+		});
 
-    conn.interceptors.request.use((config: any) => {
-      new Log(!!verbose).debug(config);
-      return config;
-    });
-  }
+		conn.interceptors.request.use((config: any) => {
+			new Log(!!verbose).debug(config);
+			return config;
+		});
+	}
 
-  return conn;
+	return conn;
 };
 
 export const generateDeviceId = () =>
-  `nrfsim-${Math.floor(Math.random() * 1000000000000000000000)}`;
+	`nrfsim-${Math.floor(Math.random() * 1000000000000000000000)}`;
 
 export type DeviceDefaults = {
-  endpoint: string;
-  mqttMessagesPrefix: string;
-  certsResponse: string;
-  tenantId: string;
+	endpoint: string;
+	mqttMessagesPrefix: string;
+	certsResponse: string;
+	tenantId: string;
 };
 
 export type SimulatorConfig = {
-  certsResponse: string;
-  endpoint: string;
-  appFwVersion: string;
-  deviceId: string;
-  mqttMessagesPrefix: string;
-  stage: string;
-  tenantId: string;
-  appType: string;
-  services?: string;
-  apiKey?: string;
-  apiHost?: string;
-  deviceOwnershipCode?: string;
-  verbose?: boolean;
-  associate?: boolean;
-  jobExecutionPath?: any;
-  onConnect?: (deviceId: string, client?: device) => Promise<void>;
+	certsResponse: string;
+	endpoint: string;
+	appFwVersion: string;
+	deviceId: string;
+	mqttMessagesPrefix: string;
+	stage: string;
+	tenantId: string;
+	appType: string;
+	services?: string;
+	apiKey?: string;
+	apiHost?: string;
+	deviceOwnershipCode?: string;
+	verbose?: boolean;
+	associate?: string;
+	jobExecutionPath?: any;
+	onConnect?: (deviceId: string, client?: device) => Promise<void>;
 };
 
 export const associateDevice = ({
-  deviceId,
-  deviceOwnershipCode,
-  apiHost,
-  apiKey,
-  verbose,
+	deviceId,
+	deviceOwnershipCode,
+	apiHost,
+	apiKey,
+	verbose,
 }: Partial<SimulatorConfig>): Promise<void> =>
-  getConn(apiHost as string, apiKey as string, !!verbose).put(
-    `/v1/association/${deviceId}`,
-    deviceOwnershipCode,
-  );
+	getConn(apiHost as string, apiKey as string, !!verbose).put(
+		`/v1/association/${deviceId}`,
+		deviceOwnershipCode,
+	);
 
 export const getDefaults = async ({
-  deviceId,
-  endpoint,
-  mqttMessagesPrefix,
-  certsResponse,
-  apiHost,
-  apiKey,
-  deviceOwnershipCode,
-  verbose,
+	deviceId,
+	endpoint,
+	mqttMessagesPrefix,
+	certsResponse,
+	apiHost,
+	apiKey,
+	deviceOwnershipCode,
+	verbose,
+	associate,
 }: Partial<SimulatorConfig>): Promise<DeviceDefaults> => {
-  const conn = getConn(apiHost!, apiKey!, !!verbose);
-  const log = new Log(!!verbose);
+	const conn = getConn(apiHost!, apiKey!, !!verbose);
+	const log = new Log(!!verbose);
 
-  const defaults: DeviceDefaults = {
-    endpoint: endpoint || '',
-    mqttMessagesPrefix: mqttMessagesPrefix || '',
-    certsResponse: certsResponse || '',
-    tenantId: '',
-  };
+	const defaults: DeviceDefaults = {
+		endpoint: endpoint || '',
+		mqttMessagesPrefix: mqttMessagesPrefix || '',
+		certsResponse: certsResponse || '',
+		tenantId: '',
+	};
 
-  const cacheFile = cache.getFilePath(deviceId);
+	const cacheFile = cache.getFilePath(deviceId);
 
-  const cachedDefaults: DeviceDefaults = cache.exists(cacheFile)
-    ? await cache.get(cacheFile)
-    : {};
+	const cachedDefaults: DeviceDefaults = cache.exists(cacheFile)
+		? await cache.get(cacheFile)
+		: {};
 
-  if (!(endpoint && mqttMessagesPrefix)) {
-    log.debug(`Grabbing mqttEndpoint and messagesPrefix...`);
-    let defaultEndpoint = cachedDefaults.endpoint || '',
-      defaultMqttMessagesPrefix = cachedDefaults.mqttMessagesPrefix || '';
+	if (!(endpoint && mqttMessagesPrefix)) {
+		log.debug(`Grabbing mqttEndpoint and messagesPrefix...`);
+		let defaultEndpoint = cachedDefaults.endpoint || '',
+			defaultMqttMessagesPrefix = cachedDefaults.mqttMessagesPrefix || '';
 
-    if (!(defaultEndpoint && defaultMqttMessagesPrefix)) {
-      log.debug('Fetching endpoints from device API.\n');
-      const { data } = await conn.get(`/v1/account`);
-      defaultMqttMessagesPrefix = data.mqttTopicPrefix + 'm/';
-      defaultEndpoint = data.mqttEndpoint;
-    }
+		if (!(defaultEndpoint && defaultMqttMessagesPrefix)) {
+			log.debug('Fetching endpoints from device API.\n');
+			const { data } = await conn.get(`/v1/account`);
+			defaultMqttMessagesPrefix = data.mqttTopicPrefix + 'm/';
+			defaultEndpoint = data.mqttEndpoint;
+		}
 
-    if (!endpoint) {
-      defaults.endpoint = defaultEndpoint;
-    }
+		if (!endpoint) {
+			defaults.endpoint = defaultEndpoint;
+		}
 
-    if (!mqttMessagesPrefix) {
-      defaults.mqttMessagesPrefix = defaultMqttMessagesPrefix;
-    }
-  }
+		if (!mqttMessagesPrefix) {
+			defaults.mqttMessagesPrefix = defaultMqttMessagesPrefix;
+		}
+	}
 
-  if (!certsResponse) {
-    log.debug('Grabbing cert...');
-    let defaultJsonCert = cachedDefaults.certsResponse || '';
+	if (!certsResponse) {
+		log.debug('Grabbing cert...');
+		let defaultJsonCert = cachedDefaults.certsResponse || '';
 
-    if (!defaultJsonCert) {
-      log.debug('Fetching cert from device API.\n');
-      const { data } = await conn.post(
-        `/v1/devices/${deviceId}/certificates`,
-        deviceOwnershipCode,
-      );
+		// NATE: Add code here
+		if (!defaultJsonCert && associate !== 'jitp') {
+			log.debug('Fetching cert from device API.\n');
+			const { data } = await conn.post(
+				`/v1/devices/${deviceId}/certificates`,
+				deviceOwnershipCode,
+			);
 
-      defaultJsonCert = JSON.stringify(data);
-    }
+			defaultJsonCert = JSON.stringify(data);
+		}
 
-    defaults.certsResponse = defaultJsonCert;
-  }
+		defaults.certsResponse = defaultJsonCert;
+	}
 
-  let tenantId = defaults.mqttMessagesPrefix.split('/')[1];
+	let tenantId = defaults.mqttMessagesPrefix.split('/')[1];
 
-  if (!tenantId) {
-    const { data } = await conn.get(`/v1/account`);
-    tenantId = data.team.tenantId;
-  }
+	if (!tenantId) {
+		const { data } = await conn.get(`/v1/account`);
+		tenantId = data.team.tenantId;
+	}
 
-  if (!tenantId) {
-    throw new Error(
-      `Cannot continue without tenantId! defaults: ${JSON.stringify(defaults)}`,
-    );
-  }
+	if (!tenantId) {
+		throw new Error(
+			`Cannot continue without tenantId! defaults: ${JSON.stringify(defaults)}`,
+		);
+	}
 
-  defaults.tenantId = tenantId;
-  await cache.set(cacheFile, defaults);
-  return defaults;
+	defaults.tenantId = tenantId;
+	await cache.set(cacheFile, defaults);
+	return defaults;
 };
 
 export const run = async (config: SimulatorConfig): Promise<void> => {
-  const {
-    deviceId,
-    apiKey,
-    apiHost,
-    certsResponse,
-    endpoint,
-    mqttMessagesPrefix,
-    deviceOwnershipCode,
-    associate,
-    verbose,
-  } = config;
+	const {
+		deviceId,
+		apiKey,
+		apiHost,
+		certsResponse,
+		endpoint,
+		mqttMessagesPrefix,
+		deviceOwnershipCode,
+		associate,
+		verbose,
+	} = config;
 
-  const log = new Log(!!verbose);
-  config.deviceId = deviceId || generateDeviceId();
+	const log = new Log(!!verbose);
+	config.deviceId = deviceId || generateDeviceId();
 
-  // grab the defaults from the API
-  if (!(apiKey && apiHost)) {
-    log.error(
-      `ERROR: apiKey: (passed val: "${apiKey}") and apiHost (passed val: "${apiHost}") are required`,
-    );
-    return;
-  }
+	// grab the defaults from the API
+	if (!(apiKey && apiHost)) {
+		log.error(
+			`ERROR: apiKey: (passed val: "${apiKey}") and apiHost (passed val: "${apiHost}") are required`,
+		);
+		return;
+	}
 
-  log.debug(
-    log.prettify('INITIAL CONFIG', [
-      ['DEVICE ID', config.deviceId],
-      ['DEVICE PIN', config.deviceOwnershipCode!],
-      ['API HOST', config.apiHost!],
-      ['API KEY', config.apiKey!],
-      ['TENANT ID', config.tenantId],
-      ['STAGE', config.stage],
-    ]),
-  );
+	log.debug(
+		log.prettify('INITIAL CONFIG', [
+			['DEVICE ID', config.deviceId],
+			['DEVICE PIN', config.deviceOwnershipCode!],
+			['API HOST', config.apiHost!],
+			['API KEY', config.apiKey!],
+			['TENANT ID', config.tenantId],
+			['STAGE', config.stage],
+		]),
+	);
 
-  const defaults: DeviceDefaults = await getDefaults({
-    deviceId: config.deviceId,
-    deviceOwnershipCode,
-    mqttMessagesPrefix,
-    certsResponse,
-    endpoint,
-    apiHost,
-    apiKey,
-    verbose,
-  });
+	const defaults: DeviceDefaults = await getDefaults({
+		deviceId: config.deviceId,
+		deviceOwnershipCode,
+		mqttMessagesPrefix,
+		certsResponse,
+		endpoint,
+		apiHost,
+		apiKey,
+		verbose,
+		associate,
+	});
 
-  config.certsResponse = defaults.certsResponse;
-  config.mqttMessagesPrefix = defaults.mqttMessagesPrefix;
-  config.endpoint = defaults.endpoint;
-  config.tenantId = defaults.tenantId;
+	config.certsResponse = defaults.certsResponse;
+	config.mqttMessagesPrefix = defaults.mqttMessagesPrefix;
+	config.endpoint = defaults.endpoint;
+	config.tenantId = defaults.tenantId;
 
-  log.info(
-    log.prettify('CONFIG', [
-      ['DEVICE ID', config.deviceId],
-      ['DEVICE PIN', config.deviceOwnershipCode!],
-      ['API HOST', config.apiHost!],
-      ['API KEY', config.apiKey!],
-      ['TENANT ID', config.tenantId],
-      ['STAGE', config.stage],
-    ]),
-  );
+	log.info(
+		log.prettify('CONFIG', [
+			['DEVICE ID', config.deviceId],
+			['DEVICE PIN', config.deviceOwnershipCode!],
+			['API HOST', config.apiHost!],
+			['API KEY', config.apiKey!],
+			['TENANT ID', config.tenantId],
+			['STAGE', config.stage],
+		]),
+	);
 
-  log.success('starting simulator...');
+	log.success('starting simulator...');
 
-  if (associate) {
-    config.onConnect = async (deviceId) => {
-      log.info(
-        `ATTEMPTING TO ASSOCIATE ${config.deviceId} WITH API KEY ${config.apiKey} VIA ${config.apiHost}`,
-      );
+	if (associate) {
+		config.onConnect = async (deviceId) => {
+			log.info(
+				`ATTEMPTING TO ASSOCIATE ${config.deviceId} WITH API KEY ${config.apiKey} VIA ${config.apiHost}`,
+			);
 
-      // wait to ensure the device is available in AWS IoT so it can be associated
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+			// wait to ensure the device is available in AWS IoT so it can be associated
+			await new Promise((resolve) => setTimeout(resolve, 2000));
 
-      try {
-        await associateDevice({
-          deviceId,
-          deviceOwnershipCode,
-          apiHost,
-          apiKey,
-          verbose,
-        });
+			try {
+				await associateDevice({
+					deviceId,
+					deviceOwnershipCode,
+					apiHost,
+					apiKey,
+					verbose,
+				});
 
-        log.success('DEVICE ASSOCIATED!');
-      } catch (err) {
-        log.error(`Failed to associate: ${err}`);
-      }
-    };
-  }
+				log.success('DEVICE ASSOCIATED!');
+			} catch (err) {
+				log.error(`Failed to associate: ${err}`);
+			}
+		};
+	}
 
-  simulator(config).catch((err) => {
-    log.error(err);
-  });
+	simulator(config).catch((err) => {
+		log.error(err);
+	});
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,14 +296,13 @@ export const run = async (config: SimulatorConfig): Promise<void> => {
   if (onboard) {
     config.onConnect = async (deviceId) => {
       log.info(
-        `ATTEMPTING TO ONBOARD ${config.deviceId} via ${onboard} WITH API KEY ${config.apiKey} VIA ${config.apiHost}`,
+        `ATTEMPTING TO ONBOARD ${config.deviceId} USING ${onboard} CERTS WITH API KEY ${config.apiKey} VIA ${config.apiHost}`,
       );
 
-      // wait to ensure the device is available in AWS IoT so it can be associated
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-
       try {
-        if (onboard === 'jitp') {
+				if (onboard === 'jitp') {
+					// wait to ensure the device is available in AWS IoT so it can be associated
+					await new Promise((resolve) => setTimeout(resolve, 2000));
           await associateDevice({
             deviceId,
             deviceOwnershipCode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@ import { device } from 'aws-iot-device-sdk';
 import { AxiosInstance } from 'axios/index';
 import axios from 'axios';
 import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 import { simulator } from './simulator';
 import { Log } from './models/Log';
@@ -75,17 +78,18 @@ export const associateDevice = ({
   );
 
 export const onboardDevice = ({
-	deviceId,
-	certsResponse,
-	apiHost,
-	apiKey,
-	verbose,
+  deviceId,
+  certsResponse,
+  apiHost,
+  apiKey,
+  verbose,
 }: Partial<SimulatorConfig>) => {
-	const certificate = JSON.parse(certsResponse as string).certificate;
-	return getConn(apiHost as string, apiKey as string, !!verbose).post(
-	`v1/devices/${deviceId}`, certificate
-)
-}
+  const certificate = JSON.parse(certsResponse as string).certificate;
+  return getConn(apiHost as string, apiKey as string, !!verbose).post(
+    `v1/devices/${deviceId}`,
+    certificate,
+  );
+};
 
 export const getDefaults = async ({
   deviceId,
@@ -139,35 +143,64 @@ export const getDefaults = async ({
     log.debug('Grabbing cert...');
     let defaultJsonCert = cachedDefaults.certsResponse || '';
 
-    // NATE: Add code here
     if (!defaultJsonCert) {
-			if (associate === 'jitp') {
-				log.debug('Fetching cert from device API.\n');
-				const { data } = await conn.post(
-					`/v1/devices/${deviceId}/certificates`,
-					deviceOwnershipCode,
-				);
-	
-				defaultJsonCert = JSON.stringify(data);
-			} else {
-				log.debug('Generating self signed device certs.\n');
-				const privateKey = execSync(`openssl ecparam -name prime256v1 -genkey`);
+      if (associate === 'jitp') {
+        log.debug('Fetching cert from device API.\n');
+        const { data } = await conn.post(
+          `/v1/devices/${deviceId}/certificates`,
+          deviceOwnershipCode,
+        );
 
-				const subject = "/C=NO/ST=Norway/L=Trondheim/O=Nordic Semiconductor/OU=Test Devices"
-				const caCert = execSync(`echo "${privateKey}" | openssl req -x509 -extensions v3_ca -new -nodes -key /dev/stdin -sha256 -days 1024 -subj "${subject}"`);
-				console.debug('CA Cert', caCert);
+        defaultJsonCert = JSON.stringify(data);
+      } else {
+        log.debug('Generating self signed device certs.\n');
 
-				let deviceCSR = execSync(`openssl ecparam -name prime256v1 -genkey`);
-				console.debug('ECC', deviceCSR);
-				deviceCSR = execSync(`echo "${deviceCSR}" | openssl pkcs8 -topk8 -nocrypt -in /dev/stdin`);
-				console.debug('Device PEM', deviceCSR);
-				deviceCSR = execSync(`echo "${deviceCSR}" | openssl req -new -key /dev/stdin -subj "${subject}/CN=${deviceId}"`);
-				console.debug('Device CSR', deviceCSR);
-				deviceCSR = execSync(`openssl x509 -req -in <(echo "${deviceCSR}") -CA <(echo "${caCert}") -CAkey <(echo"${privateKey}") -CAcreateserial -days 10950 -sha256`)
-				console.debug('Device Cert', deviceCSR);
+        const privateKey = execSync(
+          `openssl ecparam -name prime256v1 -genkey`,
+        ).toString();
 
-				defaultJsonCert = JSON.stringify({privateKey, caCert, certificate: deviceCSR})
-			}
+        const subject =
+          '/C=NO/ST=Norway/L=Trondheim/O=Nordic Semiconductor/OU=Test Devices';
+        const caCert = execSync(
+          `echo "${privateKey}" | openssl req -x509 -extensions v3_ca -new -nodes -key /dev/stdin -sha256 -days 1024 -subj "${subject}"`,
+        ).toString();
+
+        let deviceCSR = execSync(
+          `openssl ecparam -name prime256v1 -genkey`,
+        ).toString();
+        deviceCSR = execSync(
+          `echo "${deviceCSR}" | openssl pkcs8 -topk8 -nocrypt -in /dev/stdin`,
+        ).toString();
+        deviceCSR = execSync(
+          `echo "${deviceCSR}" | openssl req -new -key /dev/stdin -subj "${subject}/CN=${deviceId}"`,
+        ).toString();
+
+        const tempDir = os.tmpdir();
+        const csrPath = path.join(tempDir, 'device.csr');
+        const caCertPath = path.join(tempDir, 'ca.crt');
+        const privateKeyPath = path.join(tempDir, 'ca.key');
+
+        try {
+          // Write inputs to temporary files
+          fs.writeFileSync(csrPath, deviceCSR);
+          fs.writeFileSync(caCertPath, caCert);
+          fs.writeFileSync(privateKeyPath, privateKey);
+          deviceCSR = execSync(
+            `openssl x509 -req -in "${csrPath}" -CA "${caCertPath}" -CAkey "${privateKeyPath}" -CAcreateserial -days 10950 -sha256`,
+          ).toString();
+        } catch (err) {
+          console.error(err);
+        } finally {
+          fs.unlinkSync(csrPath);
+          fs.unlinkSync(caCertPath);
+          fs.unlinkSync(privateKeyPath);
+        }
+        defaultJsonCert = JSON.stringify({
+          privateKey,
+          caCert,
+          clientCert: deviceCSR,
+        });
+      }
     }
 
     defaults.certsResponse = defaultJsonCert;
@@ -226,6 +259,7 @@ export const run = async (config: SimulatorConfig): Promise<void> => {
     ]),
   );
 
+  console.debug(associate);
   const defaults: DeviceDefaults = await getDefaults({
     deviceId: config.deviceId,
     deviceOwnershipCode,
@@ -259,24 +293,32 @@ export const run = async (config: SimulatorConfig): Promise<void> => {
   if (associate) {
     config.onConnect = async (deviceId) => {
       log.info(
-        `ATTEMPTING TO ${associate === 'jitp'? 'ASSOCIATE': 'ONBOARD'} ${config.deviceId} WITH API KEY ${config.apiKey} VIA ${config.apiHost}`,
+        `ATTEMPTING TO ${associate === 'jitp' ? 'ASSOCIATE' : 'ONBOARD'} ${
+          config.deviceId
+        } WITH API KEY ${config.apiKey} VIA ${config.apiHost}`,
       );
 
       // wait to ensure the device is available in AWS IoT so it can be associated
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
       try {
-				if (associate === 'jitp') {
-					await associateDevice({
-						deviceId,
-						deviceOwnershipCode,
-						apiHost,
-						apiKey,
-						verbose,
-					});
-				} else {
-					await onboardDevice({deviceId, apiHost, apiKey, certsResponse, verbose})
-				}
+        if (associate === 'jitp') {
+          await associateDevice({
+            deviceId,
+            deviceOwnershipCode,
+            apiHost,
+            apiKey,
+            verbose,
+          });
+        } else {
+          await onboardDevice({
+            deviceId,
+            apiHost,
+            apiKey,
+            certsResponse,
+            verbose,
+          });
+        }
 
         log.success('DEVICE ASSOCIATED!');
       } catch (err) {

--- a/src/nrfDevice.ts
+++ b/src/nrfDevice.ts
@@ -36,8 +36,6 @@ export const nrfDevice = (
   let shadowInitialized = false;
   log.success(`connecting to "${endpoint}"...`);
 
-  // console.debug()
-
   const client = mqttClient({
     id: deviceId,
     caCert,
@@ -88,14 +86,14 @@ export const nrfDevice = (
       let didHaveError = false;
 
       // listen for jobs, if associated
-      log.debug(`checking to see if device ${deviceId} has been associated...`);
+      log.debug(`checking to see if device ${deviceId} has been onboarded...`);
 
       await apiConn
         .get(`v1/devices/${deviceId}`)
         .then(async (res: AxiosResponse) => {
           if (res?.data?.tenantId === tenantId) {
             log.success(
-              `confirmed that "${deviceId}" has been associated with account "${tenantId}"!`,
+              `confirmed that "${deviceId}" has been onboarded with account "${tenantId}"!`,
             );
             deviceAssociated = true;
 
@@ -126,7 +124,7 @@ export const nrfDevice = (
         .finally(() => {
           if (!deviceAssociated && !didHaveError) {
             log.info(
-              `Cannot initialize jobs listener until the device "${deviceId}" is associated to your account. You can associate the device by running "npx @nrfcloud/device-simulator-v2 -k <api key> -d ${deviceId} -a".`,
+              `Cannot initialize jobs listener until the device "${deviceId}" is onboarded to your account. You can onboard the device by running "npx @nrfcloud/device-simulator-v2 -k <api key> -d ${deviceId} -a preconnect".`,
             );
           }
         });

--- a/src/nrfDevice.ts
+++ b/src/nrfDevice.ts
@@ -36,6 +36,8 @@ export const nrfDevice = (
   let shadowInitialized = false;
   log.success(`connecting to "${endpoint}"...`);
 
+  // console.debug()
+
   const client = mqttClient({
     id: deviceId,
     caCert,


### PR DESCRIPTION
## Problem
We added a way to connect a single device to nRF Cloud via the  [Onboard Device API](https://api.nrfcloud.com/v1/#tag/IP-Devices/operation/OnboardDevice), and the simulator only could connect via the [Associate Device API](https://api.nrfcloud.com/v1/#tag/IP-Devices/operation/AssociateDevice) endpoint.

## Solution
1. Change the `-a` flag to allow for two options `jitp` or `preconnect`
2. With preconnect it will create a CA cert, then a CSR required for connection
3. Then it will call the Onboard device endpoint mentioned above.

## Testing
1. Checkout this branch
2. `yarn build`
3. Simulate a device with `-a preconnect` or `-a jitp` for the old way:
``` sh
node dist/cli.js -k <api-key> -d <deviceId> -h https://api.dev.nrfcloud.com -a preconnect -t atv2
```
4. Everything should look green :)

### Jira
https://nordicsemi.atlassian.net/browse/IRIS-8917